### PR TITLE
Feature frontera support

### DIFF
--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -580,6 +580,8 @@ class SeisFlows:
 
             ogpars.pop(module)  # don't edit the parameter were changing
             for key, val in ogpars.items():
+                if val is None:
+                    val = "null"
                 try:
                     setpar(key=key, val=val, file=self._args.parameter_file,
                            delim=":")

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -655,7 +655,7 @@ class SeisFlows:
                          "output_log"]:
                 path = f"path_{name}"
                 if path in pars:
-                    unix.rm(path)
+                    unix.rm(pars[path])
 
     def restart(self, force=False, **kwargs):
         """

--- a/seisflows/system/frontera.py
+++ b/seisflows/system/frontera.py
@@ -33,6 +33,12 @@ class Frontera(Slurm):
     :param user: User's username on TACC systems. Can be determined by 'whoami'
         or will be gathered from the 'USER' environment variable. Used for
         internal ssh'ing from compute nodes to login nodes.
+    :type conda_env: str
+    :param conda_env: name of the Conda environment in which you are running 
+        SeisFlows. Defaults to environment variable 'CONDA_DEFAULT_ENV'. Used
+        to activate the conda environment AFTER ssh'ing from compute to login
+        node, to ensure that the newly submitted job has access to the SeisFlows
+        environment
     :type partition: str
     :param partition: Chinook has various partitions which each have their
         own number of cores per compute node. Available are: small, normal,
@@ -46,18 +52,20 @@ class Frontera(Slurm):
 
     ***
     """
-    def __init__(self, user=None, partition="development", allocation=None, 
-                 **kwargs):
+    def __init__(self, user=None, conda_env=None, partition="development", 
+                 allocation=None, **kwargs):
         """Frontera init"""
         super().__init__(**kwargs)
 
         self.user = user or os.environ["USER"]  # alt. getpass.getuser()
+        self.conda_env = conda_env or os.environ["CONDA_DEFAULT_ENV"]
         self.partition = partition
         self.allocation = allocation
         self.mpiexec = "ibrun"
 
         # See note in file docstring for why we need this SSH call
-        self._ssh_call = f"ssh {self.user}@frontera.tacc.utexas.edu"
+        self._ssh_call = (f"ssh {self.user}@frontera.tacc.utexas.edu "
+                          f"'conda activate {self.conda_env}; ")
 
         # Internally used check parameters. Because 'development' and 'large'
         # partitions do not allow >1 job per user, we cannot use them

--- a/seisflows/system/slurm.py
+++ b/seisflows/system/slurm.py
@@ -160,7 +160,8 @@ class Slurm(Cluster):
         ])
         return _call
 
-    def _stdout_to_job_id(stdout)
+    @staticmethod
+    def _stdout_to_job_id(stdout):
         """
         The stdout message after an SBATCH job is submitted, from which we get
         the job number, differs between systems, allow this to vary

--- a/seisflows/system/slurm.py
+++ b/seisflows/system/slurm.py
@@ -289,7 +289,7 @@ def check_job_status(job_id):
     :return: status of all running jobs. 1 for pass (all jobs COMPLETED). -1 for
         fail (one or more jobs returned failing status)
     """
-    logger.debug(f"checking job status for submitted job: {job_id}")
+    logger.debug(f"monitoring job status for submitted job: {job_id}")
 
     bad_states = ["TIMEOUT", "FAILED", "NODE_FAIL",
                   "OUT_OF_MEMORY", "CANCELLED"]

--- a/seisflows/system/slurm.py
+++ b/seisflows/system/slurm.py
@@ -231,7 +231,8 @@ class Slurm(Cluster):
             f"{os.path.join(ROOT_DIR, 'system', 'runscripts', 'run')}",
             f"--funcs {funcs_fid}",
             f"--kwargs {kwargs_fid}",
-            f"--environment {self.environs or ''}"
+            f"--environment {self.environs or ''}'"
+            # f"--environment {self.environs or ''}"
         ])
 
         # Single-process jobs simply need to replace a few sbatch arguments.

--- a/seisflows/workflow/test_flow.py
+++ b/seisflows/workflow/test_flow.py
@@ -93,7 +93,7 @@ class TestFlow:
 
         # Force some internal module variables to keep testing lightweight
         logger.info("overwriting internal System parameters from given values")
-        self.system.ntask = 1
+        self.system.ntask = 3
         self.system.nproc = 1
         self.system.tasktime = .25  # 15 seconds
         self.system.walltime = 2.5  # 2.5 minutes

--- a/seisflows/workflow/test_flow.py
+++ b/seisflows/workflow/test_flow.py
@@ -93,7 +93,7 @@ class TestFlow:
 
         # Force some internal module variables to keep testing lightweight
         logger.info("overwriting internal System parameters from given values")
-        self.system.ntask = 3
+        self.system.ntask = 1
         self.system.nproc = 1
         self.system.tasktime = .25  # 15 seconds
         self.system.walltime = 2.5  # 2.5 minutes


### PR DESCRIPTION
This PR gets SeisFlows working on Frontera, and includes a few bug fixes of the SeisFlows command line tool. 

Frontera, a Texas Advanced Computing Center (TACC) supercomputer, is a SLURM based system, and therefore builds off the SLURM system module that was already written into SeisFlows. Needed to work out some key differences between Frontera and the standard SLURM implementation to get things working:

1) Frontera (and TACC supercomputers in general) does __not__ allow submitting SBATCH jobs from compute nodes, which is how SeisFlows operates (i.e., a master job on a compute node submits simulation jobs). To side step this the system.run() function SSH's from the compute node into the login node before submitting new SBATCH jobs (thanks to Ian Wang for the suggestion). During the run() function we also activate the Conda environment because it is not active after SSH.

2) Frontera does __not__ allow submitting array jobs (i.e., '--array' argument in SLURM), which is how SeisFlows submits embarrassingly parallel jobs (i.e., 10 events would get an '--array=0-9' argument to get 10 jobs with the same job number and slightly different behavior). To get around this the Frontera system.run() function submits jobs one by one, with each job getting a unique job ID. This modification required a rewrite of the 'squeue' monitoring function -- in the general SLURM implementation we would just watch one job number, which had multiple array jobs appended (e.g., 1_00, 1_01, 1_02...), whereas the Frontera implementation needs to watch multiple (related) jobs (e.g., 1, 2, 3)

The TestFlow workflow is now working on Frontera and all tests pass.

Misc. Bug fixes include
- `seisflows clean` wasn't actually deleting anything before due to a typo, fixed
- `seisflows swap` would set NoneType objects as string 'None', which is not accepted in YAML. It now sets them as string 'null'