### PR TITLE
update 2D examples

### DIFF
--- a/seisflows/examples/ex2_specfem2d_workstation_inversion_w_pyatoa.py
+++ b/seisflows/examples/ex2_specfem2d_workstation_inversion_w_pyatoa.py
@@ -26,7 +26,7 @@ class SFPyatoaEx2D(SFExample2D):
     advantage of the default SPECFEM2D stuff, onyl changes the generation of
     MODEL TRUE, the number of stations, and the setup of the parameter file.
     """
-    def __init__(self, ntask=2, niter=2, nsta=5):
+    def __init__(self, ntask=2, niter=2, nsta=5, specfem2d_repo=None):
         """
         Overload init and attempt to import Pyatoa before running example,
         overload the default number of tasks to 2, and add a new init parameter
@@ -40,8 +40,13 @@ class SFPyatoaEx2D(SFExample2D):
         :type nsta: int
         :param nsta: number of stations to include in inversion, between 1 and
             131
+        :type specfem2d_repo: str
+        :param specfem2d_repo: path to the SPECFEM2D directory which should
+            contain binary executables. If not given, SPECFEM2D will be
+            downloaded configured and compiled automatically.
         """
-        super().__init__(ntask=ntask, niter=niter)
+        super().__init__(ntask=ntask, niter=niter,
+                         specfem2d_repo=specfem2d_repo)
         self.nsta = nsta
         # -1 because it represents index but we need to talk in terms of count
         assert(1 <= self.nsta <= 131), \
@@ -154,5 +159,6 @@ if __name__ == "__main__":
     # use argparser here because we're being called by SeisFlows CLI tool which
     # is occupying argparser
     if len(sys.argv) > 1:
-        sfex2d = SFPyatoaEx2D()
+        _, _, specfem2d_repo = sys.argv
+        sfex2d = SFPyatoaEx2D(specfem2d_repo=specfem2d_repo)
         sfex2d.main()

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -44,7 +44,7 @@ class SFExample2D:
     A class for running SeisFlows examples. Simplifies calls structure so that
     multiple example runs can benefit from the code written here
     """
-    def __init__(self, ntask=3, niter=2):
+    def __init__(self, ntask=3, niter=2, specfem2d_repo=None):
         """
         Set path structure which is used to navigate around SPECFEM repositories
         and the example working directory
@@ -54,14 +54,11 @@ class SFExample2D:
             defaults to 3
         :type niter: int
         :param niter: number of iterations to run. defaults to 2
+        :type specfem2d_repo: str
+        :param specfem2d_repo: path to the SPECFEM2D directory which should
+            contain binary executables. If not given, SPECFEM2D will be
+            downloaded configured and compiled automatically.
         """
-        specfem2d_repo = input(
-            msg.cli("If you have already downloaded SPECMFE2D, please input "
-                    "the full path to the repo. If left blank, this example "
-                    "will pull the latest version from GitHub and attempt "
-                    "to configure and make the binaries:\n> ")
-        )
-
         self.cwd = os.getcwd()
         self.sem2d_paths, self.workdir_paths = self.define_dir_structures(
             cwd=self.cwd, specfem2d_repo=specfem2d_repo
@@ -365,14 +362,16 @@ if __name__ == "__main__":
                "3. Generate starting model from Tape2007 example",
                "4. Generate target model w/ perturbed starting model",
                "5. Set up a SeisFlows working directory",
-               f"6. Run an inversion workflow"],
+               "6. Run an inversion workflow"],
         header="seisflows example 1",
         border="=")
     )
 
     # Dynamically traverse sys.argv to get user-input command line. Cannot
     # use argparser here because we're being called by SeisFlows CLI tool which
-    # is occupying argparser
+    # is occupying argparser. Call looks something like:
+    # $ python /path/to/example.py run path/to/specfem2d
     if len(sys.argv) > 1:
-        sfex2d = SFExample2D()
+        _, _, specfem2d_repo = sys.argv
+        sfex2d = SFExample2D(specfem2d_repo=specfem2d_repo)
         sfex2d.main()


### PR DESCRIPTION
Updating 2D examples so that the 'specfem2d' directory can be input from the command line rather than via an input() statement. This is necessary as running SeisFlows through 'docker run' will break when encountering an input statement so we need to feed in this information from the command line. This new call looks like:

    seisflows examples run 1 --specfem2d_repo path/to/specfem2d  # or -r

Example problems now also look in '${pwd}/specfem2d' if no '-r' option given, and if it cant find a matching directory, it will fall back to downloading the latest SPECFEM2D devel version, configuring and compiling.