### PR TITLE
Plot 2D improvement for models with complex topographies

### DIFF
--- a/seisflows/tools/graphics.py
+++ b/seisflows/tools/graphics.py
@@ -48,6 +48,66 @@ def plot_2d_contour(x, z, data, cmap="viridis", zero_midpoint=False):
     return f, p, cbar
 
 
+def plot_2d_image(x, z, data, cmap="viridis", zero_midpoint=False, resX=1000, resZ=1000):
+    """
+    Plots values of a SPECEFM2D model/gradient by interpolating onto a regular grid
+
+    :type x: np.array
+    :param x: x values of GLL mesh
+    :type z: np.array
+    :param z: z values of GLL mesh
+    :type data: np.array
+    :param data: D
+    :type cmap: str
+    :param cmap: matplotlib colormap to be applied to the contour plot. Defaults
+        to 'viridis'
+    :type zero_midpoint: bool
+    :param zero_midpoint: set 0 as the midpoint for the colorbar. Useful for
+        diverging colorscales (e.g., for gradients), where the neutral color
+        (e.g., white) is set at value=0
+    :type resX: int
+    :param resX: number of points for the interpolation in x- direction (default=1000)
+    :type resZ: int
+    :param resZ: number of points for the interpolation in z- direction (default=1000)
+    """
+    # Figure out aspect ratio of the figure
+    r = (max(x) - min(x))/(max(z) - min(z))
+    rx = r/np.sqrt(1 + r**2)
+    ry = 1/np.sqrt(1 + r**2)
+
+    # Assign zero as the midpoint for things like gradients
+    if zero_midpoint:
+        abs_max_val = max(abs(data))
+        vmin = -1 * abs_max_val
+        vmax = abs_max_val
+    else:
+        vmin, vmax = None, None
+
+    f = plt.figure(figsize=(10 * rx, 10 * ry))
+    from scipy.interpolate import griddata
+
+    # trick interpolation using the maximum values of z in case of concave topography.
+    # nan values helps interpolation act expectedly.
+    # Can be tested using the default specfem2D model: simple_topography_and_also_a_simple_fluid_layer
+    x = np.append(x, [min(x), max(x)])
+    z = np.append(z, [max(z), max(z)])
+    data = np.append(data, [np.nan, np.nan])
+
+    xi = np.linspace(min(x), max(x), resX)
+    zi = np.linspace(min(z), max(z), resZ)
+    X, Z = np.meshgrid(xi, zi)
+    V = griddata((x, z), data, (X, Z), method='linear')
+    im = plt.imshow(V, vmax=vmax, vmin=vmin,
+                    extent=[x.min(), x.max(), z.min(), z.max()],
+                    cmap=cmap,
+                    origin='lower')
+
+    cbar = plt.colorbar(im, shrink=0.8, pad=0.025)
+    plt.axis("image")
+
+    return f, im, cbar
+
+
 def plot_vector(t, v, xlabel='', ylabel='', title=''):
     """
     Plots a vector or time series.

--- a/seisflows/tools/specfem.py
+++ b/seisflows/tools/specfem.py
@@ -11,7 +11,7 @@ from seisflows import logger
 from seisflows.tools.config import Dict
 from seisflows.tools import unix, msg
 from seisflows.tools.math import poissons_ratio
-from seisflows.tools.graphics import plot_2d_contour
+from seisflows.tools.graphics import plot_2d_image
 
 
 class Model:
@@ -406,8 +406,7 @@ class Model:
 
     def plot2d(self, parameter, cmap=None, show=True, title="", save=None):
         """
-        Plot internal model parameters as a 2D contour plot. Kwargs are passed
-        to underlying matplotlib.pylpot.tricontourf function.
+        Plot internal model parameters as a 2D image plot.
 
         .. warning::
             This is only available for SPECFEM2D models. SPECFEM3D model
@@ -452,8 +451,8 @@ class Model:
             z = np.append(z, self.coordinates["z"][iproc])
         data = self.merge(parameter=parameter)
 
-        f, p, cbar = plot_2d_contour(x=x, z=z, data=data, cmap=cmap,
-                                     zero_midpoint=zero_midpoint)
+        f, p, cbar = plot_2d_image(x=x, z=z, data=data, cmap=cmap,
+                                   zero_midpoint=zero_midpoint)
 
         # Set some figure labels based on information we know here
         ax = plt.gca()


### PR DESCRIPTION
Hi Bryant,

This patch adds `plot_2d_image` function and uses it in `seisflows.tools.specfem.Model` 

It adds NaN values to the top edge of the model before interpolation to the regular grid. In order to fix the representation issue with complex topographies. I have also tested with flat topography, it didn't cause problems.

I couldn't it make it work tricontourf. Feel free to explore similar fix for it. `plot_2d_image` might be slower than `plot_2d_contour` since it uses imshow which requires a interpolated regular grid.

Comparison image for the `simple_topography_and_also_a_simple_fluid_layer` specfem2D model.

```python
from seisflows.tools.specfem import Model
m = Model("DATA")
m.plot2d(parameter="vs")
```

![topo_plots](https://user-images.githubusercontent.com/77037/194652467-2948371c-7487-4a50-9cf0-304f52fdb357.png)
