### PR TITLE
Fixed problems during line search plus other minor changes

### DIFF
--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -247,7 +247,9 @@ class Gradient:
                         step_lens=self._line_search.step_lens,
                         gtg=self._line_search.gtg,
                         gtp=self._line_search.gtp,
-                        step_count=self._line_search.step_count)
+                        step_count=self._line_search.step_count,
+                        step_len_max=self._line_search.step_len_max
+                       )
 
         np.savez(file=self.path._checkpoint, **dict_out)  # NOQA
 
@@ -272,6 +274,7 @@ class Gradient:
             self._line_search.gtg = list(dict_in["gtg"])
             self._line_search.gtp = list(dict_in["gtp"])
             self._line_search.step_count = int(dict_in["step_count"])
+            self._line_search.step_len_max = float(dict_in["step_len_max"])
         else:
             logger.info("no optimization checkpoint found, assuming first run")
             self.checkpoint()

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -668,6 +668,12 @@ class Default:
 
         return st_out
 
+    def read_residuals(self, residuals_files):
+        residuals = np.array([])
+        for residuals_file in residuals_files:
+            tmp = np.loadtxt(residuals_file)
+            residuals = np.append(residuals, tmp)
+        return residuals
 
 def read_ascii(fid, origintime=None):
     """

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -478,8 +478,8 @@ class Default:
         return observed, synthetic
 
     def quantify_misfit(self, source_name=None, save_residuals=None,
-                        save_adjsrcs=None, iteration=1, step_count=0,
-                        **kwargs):
+                        export_residuals=None, save_adjsrcs=None, iteration=1,
+                        step_count=0, **kwargs):
         """
         Prepares solver for gradient evaluation by writing residuals and
         adjoint traces. Meant to be called by solver.eval_func().
@@ -551,6 +551,12 @@ class Default:
 
         if save_adjsrcs and self._generate_adjsrc:
             self._check_adjoint_traces(source_name, save_adjsrcs, synthetic)
+
+        # Exporting residuals to disk (output/) for more permanent storage
+        if export_residuals:
+            if not os.path.exists(export_residuals):
+                unix.mkdir(export_residuals)
+            unix.cp(src=save_residuals, dst=export_residuals)
 
     def finalize(self):
         """Teardown procedures for the default preprocessing class"""

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -674,12 +674,24 @@ class Default:
 
         return st_out
 
-    def read_residuals(self, residuals_files):
-        residuals = np.array([])
-        for residuals_file in residuals_files:
-            tmp = np.loadtxt(residuals_file)
-            residuals = np.append(residuals, tmp)
-        return residuals
+
+def read_residuals(self, residuals_files):
+    """
+    Convenience function to read in text files containing misfit information
+    written by `quantify_misfit` function
+    
+    :type residual_files: list of str
+    :param residual files: list of names of text files written out by each 
+    misfit quantification procedure
+    :rtype: np.array
+    :return: residuals from all files provided in `residual_files`
+    """
+    residuals = np.array([])
+    for residuals_file in residuals_files:
+        tmp = np.loadtxt(residuals_file)
+        residuals = np.append(residuals, tmp)
+    return residuals
+
 
 def read_ascii(fid, origintime=None):
     """

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -757,3 +757,10 @@ class Pyaflowa:
             for event_pdf in event_pdfs:
                 os.remove(event_pdf)
 
+
+    def read_residuals(self, residuals_files):
+        residuals = np.array([])
+        for residuals_file in residuals_files:
+            tmp = np.loadtxt(residuals_file)
+            residuals = np.append(residuals, tmp)
+        return residuals

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -301,8 +301,8 @@ class Pyaflowa:
         return f"{config.event_id}_{config.iter_tag}_{config.step_tag}"
 
     def quantify_misfit(self, source_name=None, save_residuals=None,
-                        save_adjsrcs=None, iteration=1, step_count=0,
-                        parallel=False, **kwargs):
+                        export_residuals=None, save_adjsrcs=None, iteration=1,
+                        step_count=0, parallel=False, **kwargs):
         """
         Main processing function to be called by Workflow module. Generates
         total misfit and adjoint sources for a given event with name 

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -757,10 +757,3 @@ class Pyaflowa:
             for event_pdf in event_pdfs:
                 os.remove(event_pdf)
 
-
-    def read_residuals(self, residuals_files):
-        residuals = np.array([])
-        for residuals_file in residuals_files:
-            tmp = np.loadtxt(residuals_file)
-            residuals = np.append(residuals, tmp)
-        return residuals

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -339,7 +339,7 @@ class Forward:
 
         self.system.run(run_list, path_model=self.path.model_init,
                         save_residuals=os.path.join(self.path.eval_grad,
-                                                    "residuals_{src}_{it}.txt")
+                                                    "residuals_{src}_{it}_0.txt")
                         )
 
     def prepare_data_for_solver(self, **kwargs):
@@ -425,8 +425,9 @@ class Forward:
                          "objective function")
             return
 
-        save_residuals = save_residuals.format(src=self.solver.source_name,
-                                               it="1")
+        if save_residuals:
+            save_residuals = save_residuals.format(src=self.solver.source_name,
+                                                   it="1")
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -336,12 +336,14 @@ class Forward:
                         self.evaluate_objective_function]
         else:
             run_list = [self.run_forward_simulations]
-
+            
+        # `save_residuals` hard-coded for iteration 1 and step count 0
+        # assuming workflows calling this function are evaluating the
+        # very first round of misfit quantification (i.e., i01s00)
         self.system.run(run_list, path_model=self.path.model_init,
                         save_residuals=os.path.join(self.path.eval_grad,
-                                                    "residuals_{src}_{it}_0.txt")
-                        )
-
+                                                    "residuals_{src}_1_0.txt")
+                        
     def prepare_data_for_solver(self, **kwargs):
         """
         Determines how to provide data to each of the solvers. Either by copying
@@ -426,8 +428,7 @@ class Forward:
             return
 
         if save_residuals:
-            save_residuals = save_residuals.format(src=self.solver.source_name,
-                                                   it="1")
+            save_residuals = save_residuals.format(src=self.solver.source_name)
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -429,10 +429,16 @@ class Forward:
                                                it="1",
                                                sc="1")
 
+        if self.export_residuals:
+            export_residuals = os.path.join(self.path.output, "residuals")
+        else:
+            export_residuals = False
+
         logger.debug(f"quantifying misfit with "
                      f"'{self.preprocess.__class__.__name__}'")
         self.preprocess.quantify_misfit(
             source_name=self.solver.source_name,
             save_adjsrcs=os.path.join(self.solver.cwd, "traces", "adj"),
-            save_residuals=save_residuals
+            save_residuals=save_residuals,
+            export_residuals=export_residuals
         )

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -339,7 +339,7 @@ class Forward:
 
         self.system.run(run_list, path_model=self.path.model_init,
                         save_residuals=os.path.join(self.path.eval_grad,
-                                                    "residuals_{src}_{it}_{sc}.txt")
+                                                    "residuals_{src}_{it}.txt")
                         )
 
     def prepare_data_for_solver(self, **kwargs):
@@ -426,8 +426,7 @@ class Forward:
             return
 
         save_residuals = save_residuals.format(src=self.solver.source_name,
-                                               it="1",
-                                               sc="1")
+                                               it="1")
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -339,7 +339,7 @@ class Forward:
 
         self.system.run(run_list, path_model=self.path.model_init,
                         save_residuals=os.path.join(self.path.eval_grad,
-                                                    "residuals.txt")
+                                                    "residuals_{src}_{it}_{sc}.txt")
                         )
 
     def prepare_data_for_solver(self, **kwargs):
@@ -424,6 +424,10 @@ class Forward:
             logger.debug("no preprocessing module selected, will not evaluate "
                          "objective function")
             return
+
+        save_residuals = save_residuals.format(src=self.solver.source_name,
+                                               it="1",
+                                               sc="1")
 
         logger.debug(f"quantifying misfit with "
                      f"'{self.preprocess.__class__.__name__}'")

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -225,9 +225,14 @@ class Inversion(Migration):
         logger.debug(f"quantifying misfit with "
                      f"'{self.preprocess.__class__.__name__}'")
 
-        save_residuals = save_residuals.format(src=self.solver.source_name,
-                                               it=str(self.iteration),
-                                               sc=str(self.optimize.step_count + 1))
+        # If line search, add step count as suffix in the residuals file
+        if self.path.eval_func == os.path.dirname(save_residuals):
+            save_residuals = save_residuals.format(src=self.solver.source_name,
+                                                   it=str(self.iteration),
+                                                   sc=str(self.optimize.step_count + 1))
+        else:
+            save_residuals = save_residuals.format(src=self.solver.source_name,
+                                                   it=str(self.iteration))
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")
@@ -281,12 +286,12 @@ class Inversion(Migration):
                      self.evaluate_objective_function],
                     path_model=path_model,
                     save_residuals=os.path.join(self.path.eval_grad,
-                                                "residuals_{src}_{it}_{sc}.txt")
+                                                "residuals_{src}_{it}.txt")
                 )
 
         # Override function to sum residuals into the optimization library
         residuals_files = glob(os.path.join(self.path.eval_grad,
-                            f"residuals_*_{self.iteration}_{self.optimize.step_count + 1}.txt"))
+                            f"residuals_*_{self.iteration}.txt"))
 
         residuals = self.preprocess.read_residuals(residuals_files)
         total_misfit = self.preprocess.sum_residuals(residuals)

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -289,6 +289,13 @@ class Inversion(Migration):
                                                 "residuals_{src}_{it}.txt")
                 )
 
+        # Rename exported synthetic traces so they are not overwritten by
+        # future forward simulations
+        if self.export_traces:
+            unix.mv(src=os.path.join(self.path.output, "solver"),
+                    dst=os.path.join(self.path.output,
+                                     f"solver_{self.iteration:0>2}"))
+
         # Override function to sum residuals into the optimization library
         residuals_files = glob(os.path.join(self.path.eval_grad,
                             f"residuals_*_{self.iteration}.txt"))

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -229,10 +229,16 @@ class Inversion(Migration):
                                                it=str(self.iteration),
                                                sc=str(self.optimize.step_count + 1))
 
+        if self.export_residuals:
+            export_residuals = os.path.join(self.path.output, "residuals")
+        else:
+            export_residuals = False
+
         self.preprocess.quantify_misfit(
             source_name=self.solver.source_name,
             save_adjsrcs=os.path.join(self.solver.cwd, "traces", "adj"),
             save_residuals=save_residuals,
+            export_residuals=export_residuals,
             iteration=self.iteration,
             step_count=self.optimize.step_count,
         )

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -385,6 +385,7 @@ class Inversion(Migration):
             # Save new model (m_try) and step length (alpha) for records
             self.optimize.save_vector("alpha", alpha)
             self.optimize.save_vector("m_try", m_try)
+            m_try.write(path=os.path.join(self.path.eval_func, "model"))
             del m_try  # clear potentially large model vector from memory
 
             self.optimize.finalize_search()
@@ -396,6 +397,7 @@ class Inversion(Migration):
             # Save new model (m_try) and step length (alpha) for new trial step
             self.optimize.save_vector("alpha", alpha)
             self.optimize.save_vector("m_try", m_try)
+            m_try.write(path=os.path.join(self.path.eval_func, "model"))
             del m_try  # clear potentially large model vector from memory
 
             # Checkpoint and re-run line search evaluation

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -226,13 +226,14 @@ class Inversion(Migration):
                      f"'{self.preprocess.__class__.__name__}'")
 
         # If line search, add step count as suffix in the residuals file
-        if self.path.eval_func == os.path.dirname(save_residuals):
-            save_residuals = save_residuals.format(src=self.solver.source_name,
-                                                   it=str(self.iteration),
-                                                   sc=str(self.optimize.step_count + 1))
-        else:
-            save_residuals = save_residuals.format(src=self.solver.source_name,
-                                                   it=str(self.iteration))
+        if save_residuals:
+            if save_residuals.endswith("_{sc}.txt"):
+                save_residuals = save_residuals.format(src=self.solver.source_name,
+                                                       it=str(self.iteration),
+                                                       sc=str(self.optimize.step_count + 1))
+            else:
+                save_residuals = save_residuals.format(src=self.solver.source_name,
+                                                       it=str(self.iteration))
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")
@@ -286,7 +287,7 @@ class Inversion(Migration):
                      self.evaluate_objective_function],
                     path_model=path_model,
                     save_residuals=os.path.join(self.path.eval_grad,
-                                                "residuals_{src}_{it}.txt")
+                                                "residuals_{src}_{it}_0.txt")
                 )
 
         # Rename exported synthetic traces so they are not overwritten by
@@ -298,7 +299,7 @@ class Inversion(Migration):
 
         # Override function to sum residuals into the optimization library
         residuals_files = glob(os.path.join(self.path.eval_grad,
-                            f"residuals_*_{self.iteration}.txt"))
+                            f"residuals_*_{self.iteration}_0.txt"))
 
         residuals = self.preprocess.read_residuals(residuals_files)
         total_misfit = self.preprocess.sum_residuals(residuals)


### PR DESCRIPTION
Hi @bch0w,

I detected and fixed 4 problems that occurred during the line search:

1. **Residuals were incorrectly written sometimes.** The residuals from all events were written to the same file, i.e., `residuals.txt`. This means that different MPI processes wrote to `residuals.txt` at the same time. On some occasions this resulted in the following:

                    residual1
                    residual2
                    residual3residual4

    which caused `np.loadtxt('residuals.txt')` to fail on reading the file. I modified SeisFlows so residuals are written to one file per event, that is, `residuals_event_iteration_stepcount.txt`. This modification fixes the problem. Also, it helps to know how many measurements are taken per event during each iteration. It may be a good idea to also write the observation name for tracking purposes.

2. **Residuals from line search attempts were written to the same `residuals.txt` file.** Therefore, the misfit during line search was incorrect, that is, step_1_misfit=sum(residuals_step_1), step_2_misfit=sum(residuals_step_1, residuals_step_2), etc. This is fixed by my previous modification.

3. **The trial model `m_try` was exposed to the solver only during the start of the line search.** Subsequent trial models were not exposed to the solver which made the line search malfunction. I fixed this by exposing the trial model during the `perform_line_search` subroutine.

4. **The maximum step length was incorrectly defined when resuming the workflow.** The maximum step length `step_len_max` was not saved on `gradient.checkpoint` nor loaded on `gradient.load`. Therefore, every time the optimization module was resumed and `optmization.__init__` ran, `step_len_max` was set to the value defined by the user instead of as a fraction of the model as in `optimization.initialize_line_search`. This resulted in the optimization module applying the maximum step length safe guard repeatedly until the line search failed since `step_len_max` as defined by the user is a small value (less than 1).

Additionally:

1.  **Residuals are now exported when `export_residuals =  True`** (the variable already existed but it was not used.)
2. **Synthetic traces computed on `evaluate_initial_misfit` are now exported on each iteration** (previously they were overwritten every time `run_forward_simulations` was called.)

Feel free to modify my changes or discard the ones you do not like!