### PR TITLE
Improving Pyaflowa preprocessing and additional bugfixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pypdf",
 	"IPython",
 	"dill",
-	"pyatoa>=0.3.0",
+	"pyatoa>=0.4.0",
     "pysep-adjtomo",
 ]
 

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -137,6 +137,11 @@ class Gradient:
             step_count_max=step_count_max, step_len_max=step_len_max,
         )
 
+    def __str__(self):
+        """Quickly access underlying line search search history, mostly for
+        debug purposes"""
+        return self._line_search.__str__()
+
     @property
     def step_count(self):
         """Convenience property to access `step_count` from line search"""
@@ -628,6 +633,7 @@ class Gradient:
                 header = ",".join(keys) + "\n"
                 f_.write(header)
                 # Write values for first iteration
+                _write_vals = []
                 for key in keys:
                     if key == "step_length":
                         val = x[0]
@@ -635,8 +641,9 @@ class Gradient:
                         val = f[0]
                     else:
                         val = 0
-                    f_.write(f"{val:6.3E}")  
-                f_.write("\n")
+                    _write_vals.append(f"{val:6.3E}") 
+                stats_str = ",".join(_write_vals) + "\n"
+                f_.write(stats_str)  
 
         # Write stats for the current, finished, line search
         stats = self.get_stats()

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -161,6 +161,10 @@ class Bracket:
         often preferable to restart the line search. To do this, we roll back
         the number of steps we have taken during the line search, and undo
         variable changes that took place in 'initialize_search'. 
+        
+        .. note::
+            In order to proceed with workflow after running this function you 
+            will need to restart the workflow from `initialize_line_search`
         """
         logger.info("restarting line search for the current iteration")
 

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -556,7 +556,7 @@ class Pyaflowa:
                 mgmt.window()
             mgmt.measure()
         except Exception as e:
-            station_logger.warning(e)
+            station_logger.warning(f"FLOW FAILED: {e}")
             pass
 
         # Plot waveform + map figure. Map may fail if we don't have appropriate

--- a/seisflows/system/workstation.py
+++ b/seisflows/system/workstation.py
@@ -156,6 +156,7 @@ class Workstation:
                 logger.critical(f"`array` argument can not be parsed by System "
                                 f"module. Please check error message: {e}")
                 sys.exit(-1)
+            logger.info(f"`system.array` == {self.array}")
     
         assert(isinstance(self.rerun, int)), f"`rerun` must be an int [0,inf)"
         assert(self.rerun >= 0), f"`rerun` must be in bounds [0, inf)"

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -398,7 +398,8 @@ class Forward:
             # Manual overwrite to not run forward simulations
             if _preproc_only:
                 logger.warning("user request that NO forward simulation be run")
-                run_list = [self.evaluate_objective_function]
+                run_list = [self.prepare_data_for_solver, 
+                            self.evaluate_objective_function]
         else:
             run_list = [self.run_forward_simulations]
 

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -193,6 +193,7 @@ class Forward:
             _task_names = [task.__name__ for task in self.task_list]
             assert(self.stop_after in _task_names), \
                 f"workflow parameter `stop_after` must match {_task_names}"
+            logger.info(f"`workflow.stop_after` == {self.stop_after}")
 
     def setup(self):
         """

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -96,7 +96,7 @@ class Inversion(Migration):
         # Grab iteration from state file, or set None to have setup() set it
         if "iteration" in self._states:
             self.iteration = int(self._states["iteration"])
-            logger.debug(f"`iteration`={self.iteration} (from state file)")
+            logger.info(f"`workflow iteration` == {self.iteration}")
         else:
             self.iteration = None
 

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -469,6 +469,7 @@ class Inversion(Migration):
         # and is required for the line search 
         logger.info("calculating search direction `p_new` from gradient")
         p_new = self.optimize.compute_direction()
+        self.optimize.checkpoint()
         self.optimize.save_vector(name="p_new", m=p_new)
 
     def initialize_line_search(self):

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -469,6 +469,8 @@ class Inversion(Migration):
         # and is required for the line search 
         logger.info("calculating search direction `p_new` from gradient")
         p_new = self.optimize.compute_direction()
+
+        # Save optimization updates to disk for restarts/checkpoint
         self.optimize.checkpoint()
         self.optimize.save_vector(name="p_new", m=p_new)
 

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -96,7 +96,7 @@ class Inversion(Migration):
         # Grab iteration from state file, or set None to have setup() set it
         if "iteration" in self._states:
             self.iteration = int(self._states["iteration"])
-            logger.info(f"`workflow iteration` == {self.iteration}")
+            logger.info(f"`workflow.iteration` == {self.iteration}")
         else:
             self.iteration = None
 

--- a/seisflows/workflow/migration.py
+++ b/seisflows/workflow/migration.py
@@ -198,7 +198,7 @@ class Migration(Forward):
                 # region so we modify the amplitude 
                 maskv = mask_model.vector
                 if self.solver.scale_mask_region:
-                    logger.info(f"scaling source mask by 
+                    logger.info(f"scaling source mask by "
                                 {self.solver.scale_mask_region}")
                     maskv[maskv < 1] *= self.solver.scale_mask_region  
 

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -303,7 +303,7 @@ class NoiseInversion(Inversion):
         self._cmpnt = "Z"
         super().run_adjoint_simulations()
 
-    def evaluate_rt_misfit(self):
+    def evaluate_rt_misfit(self, **kwargs):
         """
         Run the forward solver to generate E and N SGFs from E and N component
         FORCES. Preprocessing will wait until the N simulations have finished
@@ -325,12 +325,13 @@ class NoiseInversion(Inversion):
             self._force = force
             logger.info(f"running misfit evaluation for: '{self._force}'")
             # Residuals file e.g., 'residuals_{src}_i01s00_RT.txt'
-            self.evaluate_initial_misfit(
-                save_residuals=os.path.join(
-                    self.path.eval_grad, "residuals",
-                    f"residuals_{{src}}_{self.evaluation}_RT.txt"),
-                sum_residuals=False
-            )
+            save_residuals = os.path.join(
+                self.path.eval_grad, "residuals",
+                f"residuals_{{src}}_{self.evaluation}_RT.txt"
+                )
+            self.evaluate_initial_misfit(save_residuals=save_residuals,
+                                         sum_residuals=False, **kwargs
+                                         )
         self._rename_preprocess_files(tag="RT")
 
     def run_rt_adjoint_simulations(self):

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1081,3 +1081,19 @@ class NoiseInversion(Inversion):
         for force in cfg.keys():
             self._states[f"evaluate_line_search_misfit_{force}"] = 0
 
+    def custom_function_sum_kernels(self):
+        """Generate ZZ, RR and TT misfit kernels (summation of event kernels)"""
+        def sum_kernels(**kwargs):
+            kernels = ["ZZ"]  # For after 'evaluate_zz_adjoint_simulation'
+            # kernels = ["ZZ", "RR", "TT"]
+            parameters = [f"{par}_kernel" for par in self.solver._parameters]
+            base_path = os.path.join(self.path.eval_grad, "kernels")
+            for kernel in kernels:
+                input_paths = []
+                output_path = os.path.join(base_path, f"{kernel}")
+
+                for srcname in self.solver.source_names:
+                    input_paths.append(os.path.join(base_path, srcname, kernel))
+
+                self.solver.combine(input_paths, output_path, parameters)
+        self.system.run([sum_kernels], single=True)

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1016,24 +1016,6 @@ class NoiseInversion(Inversion):
         # a misfit kernel, and applies smoothing, masking, etc.
         super().postprocess_event_kernels()
 
-# Copy paste into your workflow and run from the debugger
-    def CUSTOM_combine_kernels(self):
-        """DELETE ME"""
-        def combine_kernels(self, **kwargs):
-            parameters = [f"{par}_kernel" for par in self.solver._parameters]
-            for kernel in ["R", "T"]:
-                for srcname in self.solver.source_names:
-                    base_path = (f"/import/c1/ERTHQUAK/bhchow/work/seisflows/"
-                                 f"SYNVERSION/scratch/eval_grad/kernels/{srcname}/")
-
-                    input_paths = [os.path.join(base_path, f"E{kernel}"),
-                                os.path.join(base_path, f"N{kernel}")]
-                    output_path = os.path.join(base_path, f"{kernel}{kernel}")
-
-                    self.solver.combine(input_paths, output_path, parameters)
-
-            self.system.run([combine_kernels], single=True)
-
     def evaluate_line_search_misfit(self):
         """
         Function Overwrite of `workflow.inversion._evaluate_line_search_misfit`


### PR DESCRIPTION
## Change log: 

### Pyaflowa Preprocessing
- Added Preprocess.Pyaflowa parameter `revalidate` which will revalidate misfit windows when parameter `fix_windows` is 'ITER' or True. Windows which do not fall into the acceptable criteria (time shift, dlna) will be removed. Previously all windows which had been previously gathered were re-used, which led to issues of cycle skipping or very large time shifts that would stall an inversion
- Fixed up Pyaflowa processing log messaging to match the remainder of the SeisFlows logs and to be more apparent when a processing step has failed
- Bump Pyatoa dependency to 0.4.0 to access latest Pyatoa release features
- Pyaflowa preprocessing now allows for specific components to be selected during window retrieval which reduces chance of error due to mismatching components

### Misc. Features
- Added a print function for line search for debugging purposes
- SeisFlows.check() now logs a few key pieces of information that would be annoying to get wrong when running a workflow (e.g,. array, stop_after)

### Misc. Bugfixes
- Optimization added a checkpoint after gradient evaluation. Previously this information was lost if a workflow stopped or crashed prior to line search initialization
- Optimization stats were not being properly written to text file