### PR TITLE
Fixes examples and bugfixes solver  and default preprocessing module

### DIFF
--- a/seisflows/examples/ex3_fwd_solver.py
+++ b/seisflows/examples/ex3_fwd_solver.py
@@ -57,6 +57,7 @@ class SFFwdEx2D(SFExample2D):
         }
 
         self._parameters["export_traces"] = True
+        self._parameters["generate_data"] = False  # overload default par.
         self._parameters["path_model_true"] = "null"  # overload default par.
 
     def print_dialogue(self):
@@ -98,7 +99,6 @@ class SFFwdEx2D(SFExample2D):
         for i in range(self.nproc):
             ln("model_velocity.dat_checker",
                f"proc00000{i}_model_velocity.dat_input")
-
 
     def main(self):
         """

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -130,7 +130,7 @@ class SFExample2D:
         self._parameters = {
             "ntask": self.ntask,  # default 3 sources for this example
             "materials": "elastic",  # how velocity model parameterized
-            "density": False,  # update density or keep constant
+            "update_density": False,  # update density or keep constant
             "syn_data_format": "ascii",  # how to output synthetic seismograms
             "obs_data_format": "ascii",
             "unit_output": "disp",
@@ -138,7 +138,6 @@ class SFExample2D:
             "start": 1,  # first iteration
             "end": self.niter,  # final iteration -- we will run 2
             "step_count_max": 5,  # will cause iteration 2 to fail
-            "data_case": "synthetic",  # synthetic-synthetic inversion
             "components": "Y",  # only Y component seismograms avail.
             "attenuation": False,
             "misfit": "traveltime",  # cross-correlation phase measure

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -362,7 +362,7 @@ class SFExample2D:
         assert(os.path.exists("Par_file")), f"I cannot find the Par_file!"
 
         print("> Updating initial homogeneous velocity model values")
-        new_model = "1 1 2600.d0 5900.d0 3550.0d0 0 0 10.d0 10.d0 0 0 0 0 0 0"
+        new_model = "1 1 2600.d0 6000.d0 3625.0d0 0 0 10.d0 10.d0 0 0 0 0 0 0"
         self.sf.sempar("velocity_model", new_model)
 
     def run_xspecfem2d_binaries(self):

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -418,7 +418,7 @@ class SFExample2D:
         """
         cd(self.cwd)
 
-        self.sf.setup(force=True)  # Force will delete existing parameter file
+        self.sf.init(force=True)  # Force will delete existing parameter file
         for key, val in self._modules.items():
             self.sf.par(key, val)
 

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -141,6 +141,7 @@ class SFExample2D:
             "step_count_max": 5,  # will cause iteration 2 to fail
             "components": "Y",  # only Y component seismograms avail.
             "attenuation": False,
+            "plot_waveforms": True,  
             "misfit": "traveltime",  # cross-correlation phase measure
             "adjoint": "traveltime",  # cross-correlation phase measure
             "path_specfem_bin": self.workdir_paths.bin,

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -362,7 +362,7 @@ class SFExample2D:
         assert(os.path.exists("Par_file")), f"I cannot find the Par_file!"
 
         print("> Updating initial homogeneous velocity model values")
-        new_model = "1 1 2600.d0 6000.d0 3625.0d0 0 0 10.d0 10.d0 0 0 0 0 0 0"
+        new_model = "1 1 2600.d0 5900.d0 3550.0d0 0 0 10.d0 10.d0 0 0 0 0 0 0"
         self.sf.sempar("velocity_model", new_model)
 
     def run_xspecfem2d_binaries(self):

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -131,6 +131,7 @@ class SFExample2D:
             "ntask": self.ntask,  # default 3 sources for this example
             "materials": "elastic",  # how velocity model parameterized
             "update_density": False,  # update density or keep constant
+            "generate_data": True,  # run simulations through model_tru
             "syn_data_format": "ascii",  # how to output synthetic seismograms
             "obs_data_format": "ascii",
             "unit_output": "disp",
@@ -495,7 +496,7 @@ class SFExample2D:
         self.setup_specfem2d_for_model_init()
         self.run_xspecfem2d_binaries()
         self.cleanup_xspecfem2d_run(choice="INIT")
-        # Step 2b: Generate MODEL_INIT, rearrange consequent directory structure
+        # Step 2b: Generate MODEL_TRUE, rearrange consequent directory structure
         print(msg.cli("GENERATING TRUE/TARGET MODEL", border="="))
         self.setup_specfem2d_for_model_true()
         self.run_xspecfem2d_binaries()

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -458,8 +458,6 @@ class Gradient:
 
         if alpha is not None:
             logger.info(f"step length `alpha` = {alpha:.3E}")
-        else:
-            logger.info("step length `None`, assumed failed line search")
     
         return alpha, status
 
@@ -470,18 +468,23 @@ class Gradient:
         `alpha`
 
         :type alpha: float
-        :param alpha: step length recommended by the line search.
-        :rtype: np.array
-        :return: trial model that can be used for line search evaluation
+        :param alpha: step length recommended by the line search. if None,
+            due to failed line search, then this function returns None
+        :rtype: np.array or NoneType
+        :return: trial model that can be used for line search evaluation or 
+            None if alpha is None
         """
-        # The new model is the old model plus a step with a given magnitude 
-        m_try = self.load_vector("m_new").copy()
-        p = self.load_vector("p_new")  # current search direction
+        if alpha is not None:
+            # The new model is the old model plus a step with a given magnitude 
+            m_try = self.load_vector("m_new").copy()
+            p = self.load_vector("p_new")  # current search direction
 
-        dm = alpha * p.vector  # update = step length * step direction
-        logger.info(f"updating model with `dm` (dm_min={dm.min():.2E}, "
-                    f"dm_max = {dm.max():.2E})")
-        m_try.update(vector=m_try.vector + dm)
+            dm = alpha * p.vector  # update = step length * step direction
+            logger.info(f"updating model with `dm` (dm_min={dm.min():.2E}, "
+                        f"dm_max = {dm.max():.2E})")
+            m_try.update(vector=m_try.vector + dm)
+        else:
+            m_try = None
 
         return m_try
 

--- a/seisflows/plugins/preprocess/misfit.py
+++ b/seisflows/plugins/preprocess/misfit.py
@@ -102,7 +102,7 @@ def traveltime(syn, obs, nt, dt, *args, **kwargs):
     cc = abs(np.convolve(obs, np.flipud(syn)))
     timeshift = (np.argmax(cc) - nt + 1) * dt
 
-    return 1/2 * timeshift ** 2
+    return timeshift
 
 
 def traveltime_inexact(syn, obs, nt, dt, *args, **kwargs):

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -542,6 +542,7 @@ class Default:
                 residual = 0
 
             # Generate an adjoint source trace, write to file in scratch dir.
+            # SPECFEM expects non time-reversed adjoint sources
             if save_adjsrcs and self._generate_adjsrc:
                 adjsrc = tr_syn.copy()
                 adjsrc.data = self._generate_adjsrc(

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -537,10 +537,11 @@ class Default:
                     obs=tr_obs.data, syn=tr_syn.data,
                     nt=tr_syn.stats.npts, dt=tr_syn.stats.delta
                 )
-                # Calculate misfit from measurement, ensure misfit is a positive
-                # value so that it can be correctly compared
+                # Calculate misfit from measurement (e.g., Tromp et al. 2005 
+                # Eq. 1), ensuring misfit is a positive value so that it can be
+                # correctly compared during line search
                 residual = 1/2 * residual ** 2
-                logger.debug(f"{tr_syn.get_id()} residual={residual:.3E}")
+                logger.debug(f"{tr_syn.get_id()} misfit={residual:.3E}")
             else:
                 residual = 0
 
@@ -582,7 +583,7 @@ class Default:
                 fid_out = os.path.join(
                     fig_path, f"{tr_syn.id.replace('.', '_')}{_itr}{_stp}.png"
                 )
-                title = f"{tr_syn.id}; misfit={residual:.2f}"
+                title = f"{tr_syn.id}; misfit={residual:.3E}"
                 plot_waveforms(tr_obs=tr_obs, tr_syn=tr_syn, tr_adj=adjsrc,
                                fid_out=fid_out, title=title)
 

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -537,6 +537,9 @@ class Default:
                     obs=tr_obs.data, syn=tr_syn.data,
                     nt=tr_syn.stats.npts, dt=tr_syn.stats.delta
                 )
+                # Calculate misfit from measurement, ensure misfit is a positive
+                # value so that it can be correctly compared
+                residual = 1/2 * residual ** 2
                 logger.debug(f"{tr_syn.get_id()} residual={residual:.3E}")
             else:
                 residual = 0

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -599,8 +599,10 @@ class Default:
         # synthetics because the output adjoint sources will need this samp rate
         obs, syn = resample(st_a=obs, st_b=syn)
 
-        # Trim the observed seismograms to the length of the synthetics
-        obs, syn = trim(st=syn, st_trim=obs)
+        # Trim the observed seismograms to the length of the synthetics. 
+        # Returned in the same order as input so syn first since we are trimming
+        # to syn
+        syn, obs = trim(st=syn, st_trim=obs)
 
         # Apply some basic detrends to clean up data
         for st in [obs, syn]:

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -415,8 +415,8 @@ class Default:
         if _serial:
             for o, s in zip(obs, syn):
                 residual = self._quantify_misfit_single(o, s, source_name, 
-                                                       save_residuals, 
-                                                       save_adjsrcs)
+                                                        save_residuals, 
+                                                        save_adjsrcs)
                 residuals.append(residual)
         # Process each pair in parallel. Max workers is total num. of cores        
         else:
@@ -433,7 +433,7 @@ class Default:
                     residual = future.result()
                     residuals.append(residual)
                 except Exception as e:
-                    logger.critical(f"preprocessing error: {e}")
+                    logger.critical(f"PREPROC FAILED: {e}")
                     sys.exit(-1)
 
         # Write residuals to text file for other modules to find
@@ -566,13 +566,13 @@ class Default:
                 fig_path = os.path.join(self.path.scratch, source_name)
                 if not os.path.exists(fig_path):
                     unix.mkdir(fig_path)
-                # e.g., path/to/figure/NN_SSS_LL_CCC.png
-                if self._iteration:
-                    _itr = self._iteration
+                # e.g., path/to/figure/NN_SSS_LL_CCC_IS.png 
+                if self._iteration is not None:
+                    _itr = f"_i{self._iteration:0>2}"
                 else:
                     _itr = ""
-                if self._step_count:
-                    _stp = self.step_count
+                if self._step_count is not None:
+                    _stp = f"s{self._step_count:0>2}"
                 else:
                     _stp = ""
                 fid_out = os.path.join(
@@ -630,7 +630,6 @@ class Default:
 
         return obs, syn
 
-
 def read(fid, data_format, **kwargs):
     """
     Waveform reading functionality. Imports waveforms as Obspy streams
@@ -650,7 +649,6 @@ def read(fid, data_format, **kwargs):
     else:
         st = obspy_read(fid, format=data_format.upper(), **kwargs)
     return st
-
 
 def write(st, fid, data_format):
     """
@@ -688,7 +686,6 @@ def write(st, fid, data_format):
                 time_offset = 0
             data_out = np.vstack((tr.times() + time_offset, tr.data)).T
             np.savetxt(fid, data_out, ["%13.7f", "%17.7f"])
-
 
 def read_ascii(fid, origintime=None, **kwargs):
     """
@@ -755,7 +752,6 @@ def read_ascii(fid, origintime=None, **kwargs):
 
     return st
 
-
 def initialize_adjoint_traces(data_filenames, fmt, path_out="./"):
     """
     SPECFEM requires that adjoint traces be present for every matching
@@ -786,7 +782,6 @@ def initialize_adjoint_traces(data_filenames, fmt, path_out="./"):
             ]
     # Simply wait until this task is completed
     wait(futures)
-
 
 def _write_adjsrc_single(st, fid, output, fmt):
     """Parallelizable function to write out empty adjoint source"""

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -452,9 +452,12 @@ class Pyaflowa:
         """
         # READ DATA
         # Event metadata from SPECFEM DATA/ (CMTSOLUTION, FORCESOLUTION etc.)
+        # TEMPORARY suppress warnings to avoid PySEP warning about some sources
+        # not having an origin time. This should be removed after a PySEP update
+        # to not throw this warning
         cat = read_events_plus(
             fid=os.path.join(self.path.specfem_data,
-                             f"{self._source_prefix}_{config.event_id}"),
+                            f"{self._source_prefix}_{config.event_id}"),
             format=self._source_prefix
         )
         # Waveform input; `origintime` will only be applied if format=='ASCII'

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -1214,7 +1214,7 @@ class SeisFlows:
         plot_model.coordinates = base_model.coordinates
         # plot2d has internal check for acceptable parameter value
         plot_model.plot2d(parameter=parameter, cmap=cmap, show=True,
-                          title=f"{name} // {parameter.upper()}", save=savefig)
+                          title=f"{name} // {parameter}", save=savefig)
 
     def reset(self, choice=None, **kwargs):
         """

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -825,7 +825,7 @@ class SeisFlows:
             check = input(msg.cli("This will remove all workflow objects "
                                   "leaving only the parameter file. Are "
                                   "you sure you want to continue? "
-                                  "(y/[n])", header="clean", border="="))
+                                  "(y/[n])\n", header="clean", border="="))
 
         if check == "y":
             pars = load_yaml(self._args.parameter_file)

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -825,7 +825,7 @@ class SeisFlows:
             check = input(msg.cli("This will remove all workflow objects "
                                   "leaving only the parameter file. Are "
                                   "you sure you want to continue? "
-                                  "(y/[n])\n", header="clean", border="="))
+                                  "(y/[n])", header="clean", border="="))
 
         if check == "y":
             pars = load_yaml(self._args.parameter_file)

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -278,9 +278,6 @@ class Specfem:
 
         Exports INIT/STARTING and TRUE/TARGET models to disk (output/ dir.)
         """
-        self._initialize_working_directories()
-        self._export_starting_models()
-
         # Assign file extensions to be used for database file searching
         model_type = getpar(key="MODEL",
                             file=os.path.join(self.path.specfem_data,
@@ -291,6 +288,9 @@ class Specfem:
             logger.warning("no SPECFEM model type specified to define file "
                            "extension, defaulting to '.bin'")
             self._ext = ".bin"
+
+        self._initialize_working_directories()
+        self._export_starting_models()
 
     def check_model_values(self, path):
         """

--- a/seisflows/tools/graphics.py
+++ b/seisflows/tools/graphics.py
@@ -173,9 +173,13 @@ def plot_waveforms(tr_obs, tr_syn, tr_adj=None, fid_out=None, title=None,
         lines += twax.plot(tr_adj.times(), tr_adj.data, c=adj_color, lw=lw,
                            label="adj", ls="--", alpha=0.75, zorder=5)
         twax.set_ylabel("Adj. Amplitude")
+        twax_ylim = max(abs(tr_adj.data.min()), abs(tr_adj.data.max()))
+        twax.set_ylim([-1 * twax_ylim, twax_ylim])
 
     # Set the x-axis limits based on syn, which is what we are interested in
     ax.set_xlim([tr_syn.times()[0], tr_syn.times()[-1]])
+    ax_ylim = max(abs(tr_syn.data.min()), abs(tr_syn.data.max()))
+    ax.set_ylim([-1 * ax_ylim, ax_ylim])
 
     # Plot attributes and labels
     if title is None:

--- a/seisflows/tools/msg.py
+++ b/seisflows/tools/msg.py
@@ -150,7 +150,7 @@ def cli(text="", items=None, wraplen=80, header=None, border=None, hchar="/"):
         output_str += "\n".join(items)
     # Add bottom border
     if border is not None:
-        output_str += f"\n{border * wraplen}"
+        output_str += f"\n{border * wraplen}\n"
     # Final newline to space from next cli
     # output_str += "\n"
     return output_str

--- a/seisflows/tools/specfem.py
+++ b/seisflows/tools/specfem.py
@@ -549,7 +549,7 @@ def getpar_vel_model(file):
     :return: list of all the layers of the velocity model as strings
     """
     _, _, i_start = getpar("nbmodels", file)
-    _, _, i_end = getpar("tomography_file", file)
+    _, _, i_end = getpar("TOMOGRAPHY_FILE", file)
 
     # i_start + 1 to skip over the 'nbmodels' parameter
     lines = open(file, "r").readlines()[i_start + 1:i_end]
@@ -583,7 +583,7 @@ def setpar_vel_model(file, model):
     """
     _, nbmodels, i_start = getpar("nbmodels", file)
     i_start += 1  # increase by one to start AFTER nbmodels line
-    _, _, i_end = getpar("interfacesfile", file)
+    _, _, i_end = getpar("TOMOGRAPHY_FILE", file)
 
     lines = open(file, "r").readlines()
     model_lines = []

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -185,8 +185,7 @@ class Forward:
                     f"option `generate_data` requires 'path_model_true' "
                     f"to exist, which points to a target model"
                     )
-                assert(self.path.data is not None and
-                       os.path.exists(self.path.data)), \
+                assert(self.path.data is not None), \
                     f"`path_data` is required for data-synthetic comparisons"
 
         if self.stop_after is not None:

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -346,7 +346,7 @@ class Forward:
             )
         
         # Symlink data into solver directories so it can be found by preprocess
-        src = glob(os.path.join(save_traces, "*"))
+        src = os.path.join(save_traces, "*")
         dst = os.path.join(self.solver.cwd, "traces", "obs")
 
         for src_ in glob(src):

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -316,7 +316,10 @@ class Forward:
         """
         Barebones forward simulation to create synthetic data and export and 
         save the synthetics in the correct locations. Hijacks function
-        `run_forward_simulations` but uses some different path exports
+        `run_forward_simulations` but uses some different path exports. 
+
+        Exports data to disk in `path_data` and then symlinks to solver 
+        directories for each source.
 
         .. note::
 
@@ -330,13 +333,22 @@ class Forward:
         :param export_trace: full path to store synthetic observations so they 
             can be discovered by other functions. Defaulsts to solver/traces/obs
         """
+        # Set default arguments
+        path_model = path_model or self.path.model_true
+        export_traces = export_traces or os.path.join(self.path.data, 
+                                                      self.solver.source_name)
+        save_traces = os.path.join(self.path.data, self.solver.cwd)
+
+        # Run forward simulation with solver
         self.run_forward_simulations(
-                path_model=path_model or self.path.model_true,
-                export_traces=export_traces or 
-                        os.path.join(self.path.data, self.solver.source_name),
-                save_traces=os.path.join(self.solver.cwd, "traces", "obs"),
-                save_forward=False
-                )
+            path_model=path_model, export_traces=export_traces,  
+            save_traces=save_traces, save_forward=False
+            )
+        
+        # Symlink data into solver directories so it can be found by preprocess
+        src = save_traces
+        dst = os.path.join(self.solver.cwd, "traces", "obs")
+        unix.ln(src, dst)
 
     def evaluate_initial_misfit(self, path_model=None, save_residuals=None,
                                 _preproc_only=False, **kwargs):

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -560,8 +560,10 @@ class Inversion(Migration):
         m_try = self.optimize.compute_trial_model(alpha=alpha)
 
         # Save new model (m_try) and step length (alpha) for new trial step
-        self.optimize.save_vector("alpha", alpha)
-        self.optimize.save_vector("m_try", m_try)
+        if alpha is not None:
+            self.optimize.save_vector("alpha", alpha)
+        if m_try is not None:
+            self.optimize.save_vector("m_try", m_try)
 
         # Proceed based on the outcome of the line search
         if status.upper() == "PASS":
@@ -646,7 +648,7 @@ class Inversion(Migration):
         # Update optimization on disk 
         self.optimize.checkpoint()
 
-        # Thrifty Inversion keeps the last function evaluation for next iteration
+        # Thrifty Inversion keeps last function evaluation for next iteration
         self._thrifty_status = self._update_thrifty_status()
         if self._thrifty_status:
             unix.rm(self.path.eval_grad)


### PR DESCRIPTION
This PR fixes examples in the `devel` branch after some API changes had broken them, which includes updates and bugfixes to the Solver and Preprocessing modules. Currently all 3 examples are now working and generally matching previous results. Most importantly, fixes some critical bugs that were introduced to the Default preprocessing module in #181 

## Change Log

### Examples
- Updates parameter names to match updates that originally broke examples in #181 

### Preprocessing

- Adds developer 'serial' mode for Default preprocessing for better debugging

#### Bugfixes
- Critical: Default `trim` function was swapping obs and syn waveforms leading to incorrect misfit and adjoint sources
- Critical: Removes previous update to traveltime misfit function which did not allow negative misfit, causing incorrect adjoint sources, while retaining requirement for positive-only misfit values
- Fixes Default preprocessing waveform plotting (better scaling)
- Adds iteration and step count to file IDs of waveform figures so that subsequent plotting does not overwrite figures
- Fixes default preprocess inability to grab future results during preprocessing

### Solver
- Fixes updates to SPECFEM2D parameter file that was not allowing velocity model to be changed
- Solver was not properly copying over initial model files due to uninstantiated path (order of operations error)
- Feature `generate_data` now saves synthetic observations to disk (path_data) and then copies over to scratch directory

### General Updates
- Aesthetic fix to allow new lines after text borders on standardized messages, previously inputs were placed on the same line as the border
- Fixes workflow crashing when line search fails due to not being evaluate the NoneType that is passed around for model 