### PR TITLE
Bugfix examples not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v3.1.1 (#212)
+Small PR for some inconsistencies causing the examples to not work. 
+
+- Missing solver parameter `prune_scratch` causing SPECFEM2D to fail
+- Incorrect boolean check causing forward workflow to fail
+- Bump Devel version number 3.1.0 -> 3.1.1
+
 ## v3.1.0 (#208)
 Bugfix NoiseInversion Workflow 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.1.0"
+version = "3.1.1"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -139,6 +139,7 @@ class Specfem:
         self.smooth_v = smooth_v
         self.components = components
         self.source_prefix = source_prefix or "SOURCE"
+        self.prune_scratch = None  # SPECFEM3D/GLOBE only
 
         # Define internally used directory structure
         self.path = Dict(

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -398,7 +398,7 @@ class Forward:
         """
         # Forward workflow may not have access to optimization module, so we 
         # only tag residuals files with the source name
-        if save_residuals is None:
+        if not save_residuals:
             save_residuals = os.path.join(self.path.eval_grad, "residuals",
                                           "residuals_{src}.txt")
         else:
@@ -411,7 +411,7 @@ class Forward:
 
         # Check if we can read in the models to disk prior to submitting jobs
         # this may exit the workflow if we get a read error
-        if path_model is None:
+        if not path_model:
             logger.info("evaluating misfit for model in `path_model_init`")
             path_model = self.path.model_init
 


### PR DESCRIPTION
Small PR for some inconsistencies causing the examples to not work. 

- Missing solver parameter `prune_scratch` causing SPECFEM2D to fail
- Incorrect boolean check causing forward workflow to fail
- Bump Devel version number 3.1.0 -> 3.1.1