### PR TITLE
Implement Thrifty Inversion for NoiseInversion

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - pip
+    - numpy<=1.24
     - obspy
     - cartopy
     - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
 dependencies:
     - pip
-    - numpy<=1.24
     - obspy
     - cartopy
     - pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.1.0"
+version = "3.1.1"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [
     {email = "adjtomo@gmail.com"}
 ]
 dependencies = [
-	"numpy<=1.24",
     "obspy",
     "pyyaml",
     "pypdf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.1.1"
+version = "3.2.0"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -14,6 +14,7 @@ authors = [
     {email = "adjtomo@gmail.com"}
 ]
 dependencies = [
+	"numpy<=1.24",
     "obspy",
     "pyyaml",
     "pypdf",

--- a/seisflows/examples/sfexample2d.py
+++ b/seisflows/examples/sfexample2d.py
@@ -139,6 +139,7 @@ class SFExample2D:
             "start": 1,  # first iteration
             "end": self.niter,  # final iteration -- we will run 2
             "step_count_max": 5,  # will cause iteration 2 to fail
+            "step_len_init": 0.05,  # as a percentage of initial model
             "components": "Y",  # only Y component seismograms avail.
             "attenuation": False,
             "plot_waveforms": True,  
@@ -218,6 +219,7 @@ class SFExample2D:
         """
         if specfem2d_repo is None or not os.path.exists(specfem2d_repo):
             specfem2d_repo = os.path.join(cwd, "specfem2d")
+        specfem2d_repo = os.path.abspath(specfem2d_repo)  
 
         # This defines required structures from the SPECFEM2D repository
         sem2d = {
@@ -305,7 +307,7 @@ class SFExample2D:
         final models using one of the SPECFEM2D examples
         """
         assert(os.path.exists(self.sem2d_paths["example"])), (
-            f"SPECFEM2D/EXAMPLE directory: '{self.sem2d['example']}' "
+            f"SPECFEM2D/EXAMPLE directory: '{self.sem2d_paths['example']}' "
             f"does not exist, please check this path and try again."
         )
 

--- a/seisflows/optimize/LBFGS.py
+++ b/seisflows/optimize/LBFGS.py
@@ -72,8 +72,7 @@ class LBFGS(Gradient):
             self.line_search_method = "Backtrack"
             self._line_search = getattr(
                 line_search_dir, self.line_search_method)(
-                step_count_max=self.step_count_max,
-                step_len_max=self.step_len_max
+                    step_count_max=self.step_count_max,
             )
 
         self.LBFGS_mem = lbfgs_mem

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -460,13 +460,12 @@ class Gradient:
                 min_allowable_alpha = self.step_len_min * norm_m / norm_p
                 if alpha < min_allowable_alpha:
                     logger.warning(f"step length `alpha` is below minimum "
-                                   f"acceptable value {min_allowable_alpha} ")
+                                   f"threshold value {min_allowable_alpha:.2f}")
                     if first_step:
                         logger.info("forcing step length to minimum value")
                         alpha = min_allowable_alpha
                     else:
-                        logger.critical(msg.sub("exiting workflow because "
-                                                "step length is too small"))
+                        logger.critical(msg.mjr("EXITING WORKFLOW"))
                         sys.exit(-1)
             # Determine maximum alpha as a fraction of the current model
             if self.step_len_max:
@@ -475,7 +474,7 @@ class Gradient:
                 max_allowable_alpha = self.step_len_max * norm_m / norm_p
                 if alpha > max_allowable_alpha:
                     logger.warning(f"`alpha` has exceeded maximum value "
-                                   f"{max_allowable_alpha}, capping")
+                                   f"{max_allowable_alpha:.2f}, capping")
                     if first_step:
                         # If this is the first step, pull back slightly so that 
                         # line search can safely increase step length later

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -445,27 +445,6 @@ class Gradient:
         else:
             alpha, status = self._line_search.calculate_step_length()
 
-        # Apply step length safeguard to prevent step length from 
-        # getting too small/large w.r.t model values
-        if status == "TRY" and self.step_len_max:
-            m = m or self.load_vector("m_new")  # current model
-            p = p or self.load_vector("p_new")  # current search direction
-            norm_m = max(abs(m.vector))
-            norm_p = max(abs(p.vector))
-
-            # Determine maximum alpha as a fraction of the current model
-            logger.debug("checking safeguards min/max allowable step length "
-                         f"{self.step_len_max}")
-            max_allowable_alpha = self.step_len_max * norm_m / norm_p
-            if alpha > max_allowable_alpha:
-                logger.warning(f"safeguard: alpha has exceeded maximum step "
-                               f"length {self.step_len_max}, capping value")
-                if first_step:
-                    # If this is the first step, pull back slightly so that line 
-                    # search can safely increase step length later
-                    alpha = 0.618034 * max_allowable_alpha
-                else:
-                    alpha = max_allowable_alpha
         # Apply optional step length safeguard to prevent step length from 
         # getting too large w.r.t model values
         if status == "TRY" and (self.step_len_max or self.step_len_min):

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -28,16 +28,12 @@ class Bracket:
     :type step_count_max: int
     :param step_count_max: maximum number of step counts before changing
         line search behavior. set by PAR.STEP_COUNT_MAX
-    :type step_len_max: int
-    :param step_len_max: maximum length of the step, defaults to infinity,
-        that is unbounded step length. set by PAR.STEP_LEN_MAX
     """
-    def __init__(self, step_count_max, step_len_max, path=None):
+    def __init__(self, step_count_max, path=None):
         """
         Instantiate max criteria for line search
         """
         self.step_count_max = step_count_max
-        self.step_len_max = step_len_max
 
         if path is None:
             self.path = os.path.join(os.getcwd(), "line_search")

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -124,7 +124,6 @@ class Default:
                  late_const=None, short_dist=None, long_dist=None,
                  plot_waveforms=False, source_prefix=None,
                  workdir=os.getcwd(), path_preprocess=None, path_solver=None,
-                 path_specfem_data=None,
                  **kwargs):
         """
         Preprocessing module parameters
@@ -145,10 +144,6 @@ class Default:
         results. Defaults to current working directory
         :type path_solver: str
         :param path_solver: scratch path for solver used to access trace files
-        :type path_specfem_data: str
-        :param path_specfem_data: path to SPECFEM DATA/ directory which must
-            contain the CMTSOLUTION, STATIONS and Par_file files used for
-            running SPECFEM
         """
         self.syn_data_format = syn_data_format.upper()
         self.obs_data_format = obs_data_format.upper()
@@ -193,7 +188,6 @@ class Default:
             scratch=path_preprocess or os.path.join(workdir, "scratch",
                                                     "preprocess"),
             solver=path_solver or os.path.join(workdir, "scratch", "solver"),
-            specfem_data=path_specfem_data or None
         )
 
         # The list <_obs_acceptable_data_formats> always includes
@@ -301,14 +295,6 @@ class Default:
         assert(self.unit_output.upper() in self._acceptable_unit_output), \
             f"unit output must be in {self._acceptable_unit_output}"
 
-        # This is a redundant check on the DATA/STATIONS file (solver also
-        # runs this check). This is required by noise workflows to determine
-        # station rotation
-        assert (self.path.specfem_data is not None and
-                os.path.exists(self.path.specfem_data)), (
-            f"`path_specfem_data` must exist and must point to directory "
-            f"containing SPECFEM input files"
-        )
         # Ensure STATIONS files exist as the locations are used for preproc,
         assert(os.path.exists(
             os.path.join(self.path.specfem_data, "STATIONS"))), (

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -295,17 +295,6 @@ class Default:
         assert(self.unit_output.upper() in self._acceptable_unit_output), \
             f"unit output must be in {self._acceptable_unit_output}"
 
-        # Ensure STATIONS files exist as the locations are used for preproc,
-        assert(os.path.exists(
-            os.path.join(self.path.specfem_data, "STATIONS"))), (
-            f"DATA/STATIONS does not exist but is required by preprocessing"
-        )
-        # Ensure source files exist as their locations are used for preproc.
-        assert(glob(os.path.join(self.path.specfem_data,
-                                 f"{self.source_prefix}_*"))), (
-            f"DATA/{self.source_prefix}_* does not exist but is required"
-        )
-
     def setup(self):
         """
         Sets up data preprocessing machinery

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -578,6 +578,7 @@ class Pyaflowa:
         _waited = 0
         while True:
             try:
+                ds = None
                 with ASDFDataSet(os.path.join(self.path["_datasets"],
                                               f"{config.event_id}.h5"),
                                  mode="a") as ds:

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -434,6 +434,7 @@ class Pyaflowa:
         # Initialize empty adjoint sources for all synthetics that may or may
         # not be overwritten by the misfit quantification step
         if save_adjsrcs is not None:
+            unix.mkdir(save_adjsrcs)
             syn_filenames = glob(os.path.join(syn_path, "*"))
             initialize_adjoint_traces(data_filenames=syn_filenames,
                                       fmt=self.syn_data_format,

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -434,7 +434,6 @@ class Pyaflowa:
         # Initialize empty adjoint sources for all synthetics that may or may
         # not be overwritten by the misfit quantification step
         if save_adjsrcs is not None:
-            unix.mkdir(save_adjsrcs)
             syn_filenames = glob(os.path.join(syn_path, "*"))
             initialize_adjoint_traces(data_filenames=syn_filenames,
                                       fmt=self.syn_data_format,

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -111,8 +111,8 @@ class Pyaflowa:
                  preprocess_log_level="DEBUG",
                  export_datasets=True, export_figures=True,
                  export_log_files=True, workdir=os.getcwd(),
-                 path_preprocess=None, path_solver=None, path_specfem_data=None,
-                 path_data=None, path_output=None, obs_data_format="SAC",
+                 path_preprocess=None, path_solver=None, path_data=None,
+                 path_output=None, obs_data_format="SAC",
                  syn_data_format="ASCII", data_case="data", components=None,
                  start=None, ntask=1, nproc=1, source_prefix=None, **kwargs):
         """
@@ -182,7 +182,6 @@ class Pyaflowa:
                                                     "preprocess"),
             solver=path_solver or os.path.join(workdir, "scratch", "solver"),
             output=path_output or os.path.join(workdir, "output"),
-            specfem_data=path_specfem_data,
             data=path_data,
         )
 
@@ -229,16 +228,6 @@ class Pyaflowa:
         assert(self.syn_data_format.upper() == "ASCII"), \
             "Pyatoa preprocess requires `syn_data_format`=='ASCII'"
 
-        assert(self.path.specfem_data is not None and
-               os.path.exists(self.path.specfem_data)), (
-            f"Pyatoa requires `path_specfem_data` to exist"
-        )
-
-        assert(os.path.exists(os.path.join(self.path.specfem_data,
-                                           "STATIONS"))), \
-            f"Pyatoa preprocessing requires that the `STATIONS` file exists " \
-            f"within `path_specfem_data`"
-
         assert(self._source_prefix in self._acceptable_source_prefixes), (
             f"Pyatoa can only accept `source_prefix` in " 
             f"{self._acceptable_source_prefixes}, not '{self._source_prefix}'"
@@ -270,15 +259,6 @@ class Pyaflowa:
             pyflex_parameters=self.pyflex_parameters,
             pyadjoint_parameters=self.pyadjoint_parameters
         )
-
-        # Get station metadata from the STATIONS file to be used for processing
-        try:
-            self._inv = read_stations(
-                os.path.join(self.path.specfem_data, "STATIONS")
-            )
-        except Exception as e:
-            logger.warning(f"cannot read STATIONS file, Pyaflowa will not "
-                           f"be able to plot maps: '{e}' ")
 
     @staticmethod
     def ftag(config):
@@ -446,6 +426,16 @@ class Pyaflowa:
             syn_fmt=self.syn_data_format, components=components
         )
 
+        # Get station metadata from the STATIONS file to be used for processing
+        # We are assuming the directory structure of SPECFEM here
+        try:
+            self._inv = read_stations(
+                os.path.join(self.path.solver, source_name, "DATA", "STATIONS")
+            )
+        except Exception as e:
+            logger.warning(f"cannot read STATIONS file, Pyaflowa will not "
+                           f"be able to plot maps: '{e}' ")
+
         return observed, synthetic
 
     def _instantiate_manager(self, obs_fid, syn_fid, config):
@@ -455,16 +445,12 @@ class Pyaflowa:
         primarily for debuggin purposes as it allows the User to quickly
         retrieve an object ready for processing
         """
-        # READ DATA
         # Event metadata from SPECFEM DATA/ (CMTSOLUTION, FORCESOLUTION etc.)
-        # TEMPORARY suppress warnings to avoid PySEP warning about some sources
-        # not having an origin time. This should be removed after a PySEP update
-        # to not throw this warning
-        cat = read_events_plus(
-            fid=os.path.join(self.path.specfem_data,
-                            f"{self._source_prefix}_{config.event_id}"),
-            format=self._source_prefix
-        )
+        # e.g., scratch/solver/<SOURCE_NAME>/DATA/CMTSOLUTION
+        source_fid = os.path.join(self.path.solver, config.event_id, 
+                                  "DATA", self._source_prefix)
+        cat = read_events_plus(fid=source_fid, format=self._source_prefix)
+
         # Waveform input; `origintime` will only be applied if format=='ASCII'
         obs = read(fid=obs_fid, data_format=self.obs_data_format,
                    origintime=cat[0].preferred_origin().time)

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -860,7 +860,7 @@ class SeisFlows:
             workdir=self._args.workdir, parameter_file=self._args.parameter_file
             )
         
-        logger.info(msg.mjr("ENTERING DEBUG MODE"))
+        logger.info(msg.mjr("SEISFLOWS DEBUG", char="%"))
         print(msg.cli(
             "SeisFlows' debug mode is an embedded IPython environment. All "
             "modules are loaded by default and can be accessed by name "

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -1235,7 +1235,7 @@ class SeisFlows:
 
         TODO re-write '_reset_line_search'
         """
-        acceptable_args = {"line_search": self._reset_line_search,}
+        acceptable_args = {"line_search": self._restart_line_search,}
 
         # Ensure that help message is thrown for empty commands
         if choice not in acceptable_args.keys():
@@ -1244,6 +1244,21 @@ class SeisFlows:
 
         acceptable_args[choice](*self._args.args, **kwargs)
 
+    def _restart_line_search(self, **kwargs):
+        """
+        Reset the line search back to the initial step so that the line search
+        can be rerun with different parameter choices
+        """
+        print(msg.cli("Resetting line search to initial step", border="="))
+        workflow = import_seisflows(workdir=self._args.workdir,
+                                    parameter_file=self._args.parameter_file)
+        workflow.setup()
+        workflow.optimize._line_search._restart_line_search()
+        workflow.optimize.checkpoint()
+        print(msg.cli("Successful, resume workflow from "
+                      "'initialize_line_search`", border="="))
+
+        
     def _inspect_class_that_defined_method(self, name, func, **kwargs):
         """
         Given a function name and generalized module (e.g. solver), inspect

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -856,8 +856,9 @@ class SeisFlows:
         Does not allow stepping through of code (not a breakpoint).
         """
         from IPython import embed
-        workflow = import_seisflows(workdir=self._args.workdir,
-                            parameter_file=self._args.parameter_file)
+        workflow = import_seisflows(
+            workdir=self._args.workdir, parameter_file=self._args.parameter_file
+            )
         
         logger.info(msg.mjr("ENTERING DEBUG MODE"))
         print(msg.cli(

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -72,6 +72,8 @@ def sfparser():
     parser.add_argument("-p", "--parameter_file", nargs="?",
                         default="parameters.yaml",
                         help=f"Parameters file, default: 'parameters.yaml'")
+    parser.add_argument("-v", "--version", action="store_true",
+                        help=f"Print out the current version of SeisFlows")
 
     # Initiate a sub parser to provide nested help functions and sub commands
     subparser = parser.add_subparsers(
@@ -444,6 +446,9 @@ class SeisFlows:
             # Print out the help statement if no command is given
             if len(sys.argv) == 1:
                 self._parser.print_help()
+                sys.exit(0)
+            if self._args.version:
+                print(f"v{__version__}")
                 sys.exit(0)
 
             # Call the given function based on the user-defined name.

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -760,6 +760,10 @@ class SeisFlows:
                                     parameter_file=self._args.parameter_file)
         try:
             workflow.check()
+            print(msg.cli("All module checks passed nominally, "
+                          "use 'seisflows submit' to submit workflow", 
+                          border="-")
+                          )
         except AssertionError as e:
             print(msg.cli(str(e), border="=", header="parameter errror"))
 

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -165,7 +165,7 @@ class Specfem:
         self._ext = ""  # for database file extensions
 
         # Define available choices for check parameters
-        self._available_model_types = ["gll"]
+        self._available_model_types = ["gll", "custom_gll"]
         self._available_materials = [
             "ELASTIC", "ACOUSTIC",  # specfem2d, specfem3d
             "ISOTROPIC", "ANISOTROPIC"  # specfem3d_globe

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -153,7 +153,7 @@ class Specfem:
             model_init=path_model_init,
             model_true=path_model_true,
         )
-        self.path["mainsolver"] = os.path.join(self.path.scratch, "mainsolver")
+        self.path["_mainsolver"] = os.path.join(self.path.scratch, "mainsolver")
         self.path["_solver_output"] = os.path.join(self.path.output, "solver")
 
         # Private internal parameters for keeping track of solver requirements
@@ -521,7 +521,7 @@ class Specfem:
         """
         _model_files = []
         for par in self._parameters:
-            _model_files += glob(os.path.join(self.path.mainsolver,
+            _model_files += glob(os.path.join(self.path._mainsolver,
                                               self.model_databases,
                                               self.model_wildcard(par=par))
                                               )
@@ -1106,9 +1106,9 @@ class Specfem:
 
         # Symlink TaskID==0 as mainsolver in solver directory for convenience
         if self.source_names.index(source_name) == 0:
-            if not os.path.exists(self.path.mainsolver):
+            if not os.path.exists(self.path._mainsolver):
                 logger.debug(f"linking source '{source_name}' as 'mainsolver'")
-                unix.ln(cwd, self.path.mainsolver)
+                unix.ln(cwd, self.path._mainsolver)
 
     def _export_starting_models(self, parameters=None):
         """

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -620,10 +620,15 @@ class Specfem:
         # forward simulations are required prior to the adjoint simulation,
         # which would overwrite existing forward arrays
         if save_forward_arrays:
+            # NOTE: Relative path naming convention used, not absolute
             # scratch/solver/<source_name>/<save_forward_arrays>
             save_forward_arrays = os.path.join(self.cwd, save_forward_arrays)
-            if not os.path.exists(save_forward_arrays):
-                unix.mkdir(save_forward_arrays)
+
+            # Overwrites any existing forward arrays, for the case when we 
+            # run a thrifty line search and run multiple fwd sims consecutively 
+            unix.rm(save_forward_arrays)
+            unix.mkdir(save_forward_arrays)
+
             for glob_key in [self._forward_array_wildcard, 
                              self._absorb_wildcard]:                                   
                 unix.mv(src=glob(os.path.join(self.model_databases, glob_key)),

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -229,9 +229,14 @@ class Specfem:
             f"SPECFEM `source_prefix` must be in "
             f"{self._acceptable_source_prefixes}"
             )
-        assert(glob(os.path.join(self.path.specfem_data,
-                                 f"{self.source_prefix}*"))), (
-            f"No source files with prefix {self.source_prefix} found in DATA/")
+        _sources = glob(os.path.join(self.path.specfem_data, 
+                                     f"{self.source_prefix}_*"))
+        assert(_sources), (f"No source files with prefix {self.source_prefix} "
+                           f"found in DATA/")
+        assert(len(_sources) >= self.ntask), (
+            "Number of requested `ntasks` is larger than the number of "
+            "available source files"
+            )
 
         # Check that model type is set correctly in the Par_file
         model_type = getpar(key="MODEL",

--- a/seisflows/system/cluster.py
+++ b/seisflows/system/cluster.py
@@ -135,7 +135,7 @@ class Cluster(Workstation):
             be discouraged by sys admins as some  array processing will take 
             place on the shared login node. 
         """
-        logger.info(msg.mjr("SEISFLOWS SUBMIT"))
+        logger.info(msg.mjr("SEISFLOWS SUBMIT", char="%"))
 
         # Copy log files if present to avoid overwriting
         for src in [self.path.output_log, self.path.par_file]:

--- a/seisflows/system/cluster.py
+++ b/seisflows/system/cluster.py
@@ -135,6 +135,8 @@ class Cluster(Workstation):
             be discouraged by sys admins as some  array processing will take 
             place on the shared login node. 
         """
+        logger.info(msg.mjr("SEISFLOWS SUBMIT"))
+
         # Copy log files if present to avoid overwriting
         for src in [self.path.output_log, self.path.par_file]:
             if os.path.exists(src) and os.path.exists(self.path.log_files):

--- a/seisflows/system/workstation.py
+++ b/seisflows/system/workstation.py
@@ -199,6 +199,8 @@ class Workstation:
         :param parameter_file: parameter file name used to instantiate the
             SeisFlows package
         """
+        logger.info(msg.mjr("SEISFLOWS SUBMIT"))
+        
         # Copy log files if present to avoid overwriting
         for src in [self.path.output_log, self.path.par_file]:
             if os.path.exists(src) and os.path.exists(self.path.log_files):

--- a/seisflows/tests/test_solver.py
+++ b/seisflows/tests/test_solver.py
@@ -42,7 +42,7 @@ def test_initialize_working_directory(tmpdir):
                      path_specfem_bin=specfem_bin,
                      source_prefix="SOURCE", workdir=tmpdir
                      )
-    assert(not os.path.exists(solver.path.mainsolver))
+    assert(not os.path.exists(solver.path._mainsolver))
 
     # Set the environment task id so that the logger doesn't throw warnings
     # about not finding the task id
@@ -54,7 +54,7 @@ def test_initialize_working_directory(tmpdir):
     )
 
     # Simple checks to make sure the directory structure was set up properly
-    assert(os.path.islink(solver.path.mainsolver))
+    assert(os.path.islink(solver.path._mainsolver))
     assert(os.path.exists(solver.cwd))
     assert(glob(os.path.join(solver.cwd, "*")))
     event_fid = os.path.join(solver.cwd, "DATA", "SOURCE")

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -91,7 +91,7 @@ class Inversion(Migration):
         # Internal attribute for keeping track of inversion
         self._optimize_name = optimize
         self._required_modules = ["system", "solver", "preprocess", "optimize"]
-        self._was_thrifty = False  # keeps track of previous thrifty status
+        self._was_thrifty = True #!!!  # keeps track of previous thrifty status
 
         # Grab iteration from state file, or set None to have setup() set it
         if "iteration" in self._states:

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -421,7 +421,8 @@ class Inversion(Migration):
             # because we are assuming no solver/preprocess parameters have
             # changed. If they have, then we need to rerun the fwd solver
             if self._was_thrifty:
-                logger.info(msg.mnr("THRIFTY INVERSION; SKIP MISFIT EVAL"))
+                logger.info("thrifty inversion detected, skipping initial "
+                            "misfit evaluation")
                 return
             # Non-Thrifty, run forward simulation with previous model.
             else:
@@ -664,15 +665,16 @@ class Inversion(Migration):
         carried out. Contains some logic to consider whether or not to continue
         with a thrifty inversion.
         """
-        super().finalize_iteration()
-
-        # Export scratch files to output if requested
+        # Export scratch files to output if requested. Do this before super()
+        # so that solver can find the new model for VTK generation
         if self.export_model:
             model = self.optimize.load_vector("m_new")
             m_fid = os.path.join(self.path.output, 
                                  f"MODEL_{self.iteration:0>2}")
             logger.info(f"writing model `m_new` to {m_fid}")
             model.write(path=m_fid)
+
+        super().finalize_iteration()
 
         # Organize log files to keep file count in the main log dir. low
         logger.debug(f"organizing log files in {self.system.path.log_files}")

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -672,17 +672,16 @@ class Inversion(Migration):
         its position relative to the start and end of the workflow.
 
         .. note::
+
             Resumed, failed workflows will not re-load `_thrifty_status` so
             initial misfit will always be evaluated in that case.
         """
-        # !!! Forcing first iteration to be thrifty because i'm not going to
-        # !!! change the parameters
-        if self.iteration == self.start:
-            _thrifty_status = True
-        # if self.iteration == self.start:
-        #     logger.info("thrifty inversion encountering first iteration, "
-        #                 "defaulting to standard inversion workflow")
-        #     _thrifty_status = False
+        if self.thrifty is False:
+            _thrifty_status = False
+        elif self.iteration == self.start:
+            logger.info("thrifty inversion encountering first iteration, "
+                        "defaulting to standard inversion workflow")
+            _thrifty_status = False
         elif self.optimize._restarted:  # NOQA
             logger.info("optimization has been restarted, defaulting to "
                         "standard inversion workflow")

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -91,7 +91,7 @@ class Inversion(Migration):
         # Internal attribute for keeping track of inversion
         self._optimize_name = optimize
         self._required_modules = ["system", "solver", "preprocess", "optimize"]
-        self._was_thrifty = True #!!!  # keeps track of previous thrifty status
+        self._was_thrifty = False  # keeps track of previous thrifty status
 
         # Grab iteration from state file, or set None to have setup() set it
         if "iteration" in self._states:

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -543,9 +543,8 @@ class NoiseInversion(Inversion):
                     )
 
             # e.g., scratch/solver/001/traces/adj_zz/*.adj
-            save_adjsrcs = os.path.join(
-                self.solver.cwd, "traces", 
-                f"adj_{self._force.lower()}{self._cmpnt.lower()}"
+            save_adjsrcs = self.trace_path(
+                tag="adj", comp=f"{self._force.lower()}{self._cmpnt.lower()}"
                 )
             super().evaluate_objective_function(save_residuals=save_residuals, 
                                                 save_adjsrcs=save_adjsrcs,
@@ -1143,6 +1142,9 @@ class NoiseInversion(Inversion):
 
             # Set up for the current forward simulation
             self._force = force
+            if force == "Z":
+                self._cmpnt = "Z"  # Somewhat kludgy, required for dir. naming
+
             # If we are running a thrifty inversion we need to save the fwd
             # arrays so that the next iterations adjoint simulations can use 'em
             if self.is_thrifty:

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -137,7 +137,9 @@ class NoiseInversion(Inversion):
         super().__init__(**kwargs)
 
         self.kernels = kernels.upper()
-        self.separate_rt_kernels = separate_rt_kernels
+
+        # Commented until feature is developed/tested
+        # self.separate_rt_kernels = separate_rt_kernels
 
         # Internal variables control behavior of spawned jobs. These should not
         # be set by the User, they are set by main processing functions here.

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -942,13 +942,13 @@ class NoiseInversion(Inversion):
         # Prepare the adjoint sources which need to be loaded in from the
         # corresponding subdirectory
         unix.rm(self.trace_path(tag="adj"))
-        unix.mkdir(self.trace_path(tag="adj"))
 
         # Symlink the correct set of adjoint sources to the 'adj' directory
         # `adj_dir` is something like 'adj_nt' or 'adj_zz'
         adj_dir = self.trace_path(
             tag="adj", comp=f"{self._force.lower()}{self._cmpnt.lower()}"
         )
+        unix.mkdir(adj_dir)
         for src in glob(os.path.join(adj_dir, "*")):
             unix.ln(src, self.trace_path("adj"))
 

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -834,17 +834,16 @@ class NoiseInversion(Inversion):
         kernel_vals = None
         if self._force == "Z":
             kernel_vals = ["0.d0", "0.d0", "1.d0"]  # format: [E, N, Z]
-            # ZZ SGFs are just saved straight to the 'syn' directory
-            save_traces = save_traces or self.trace_path(tag="syn")
         else:
             if self._force == "E":
                 kernel_vals = ["1.d0", "0.d0", "0.d0"]  # format: [E, N, Z]
             elif self._force == "N":
                 kernel_vals = ["0.d0", "1.d0", "0.d0"]  # format: [E, N, Z]
 
-            # e.g., solver/{source_name}/traces/syn_e
-            save_traces = save_traces or \
-                    self.trace_path(tag="syn", comp=self._force)
+        # Synthetics saved to a separate sub-directory so that they do not 
+        # get overwritten e.g., solver/{source_name}/traces/syn_e
+        save_traces = save_traces or \
+                self.trace_path(tag="syn", comp=self._force)
 
         # Clear out synthetics from previous evaluations to avoid file conflict
         unix.rm(os.path.join(save_traces, "*"))

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -538,7 +538,7 @@ class NoiseInversion(Inversion):
             # We need to load in ZZ synthetics so that they are discoverable
             # by the misfit evaluation
             unix.rm(self.trace_path(tag="syn"))
-            unix.cp(src=self.trace_path(tag="syn", comp=self._force), 
+            unix.ln(src=self.trace_path(tag="syn", comp=self._force), 
                     dst=self.trace_path(tag="syn")
                     )
 
@@ -942,12 +942,11 @@ class NoiseInversion(Inversion):
         # Prepare the adjoint sources which need to be loaded in from the
         # corresponding subdirectory
         unix.rm(self.trace_path(tag="adj"))
+        unix.mkdir(self.trace_path(tag="adj"))
 
         # Symlink the correct set of adjoint sources to the 'adj' directory
         # `adj_dir` is something like 'adj_nt' or 'adj_zz'
-        adj_dir = self.trace_path(
-            tag="adj", comp=f"{self._force.lower()}{self._cmpnt.lower()}"
-        )
+        adj_dir = self.trace_path(tag="adj", comp=subdir.lower())
         unix.mkdir(adj_dir)
         for src in glob(os.path.join(adj_dir, "*")):
             unix.ln(src, self.trace_path("adj"))

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1102,7 +1102,7 @@ class NoiseInversion(Inversion):
         # a misfit kernel, and applies smoothing, masking, etc.
         super().postprocess_event_kernels()
 
-    def evaluate_line_search_misfit(self):
+    def evaluate_line_search_misfit(self, **kwargs):
         """
         Function Overwrite of `workflow.inversion._evaluate_line_search_misfit`
         Called inside `workflow.inversion.perform_line_search`.
@@ -1166,7 +1166,7 @@ class NoiseInversion(Inversion):
                     self.path.eval_func, "residuals",
                     f"residuals_{{src}}_{self.evaluation}_{tag}.txt"),
                 save_forward_arrays=save_forward_arrays,
-                components=components
+                components=components, **kwargs
             )
             self._rename_preprocess_files(tag)
             self._states[_state_check] = 1

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1122,12 +1122,15 @@ class NoiseInversion(Inversion):
             tag = attrs["tag"]
             components = attrs["components"]
             _state_check = f"evaluate_line_search_misfit_{force}"
-            self._force = force
 
             # Intermediate state check to see if we already ran this force
             if _state_check in self._states and \
                 bool(self._states[_state_check]):
                 continue
+
+            # Set up for the current forward simulation
+            self._force = force
+
 
             logger.info(msg.sub(f"MISFIT EVALUATION FOR FORCE '{self._force}'"))
             self.system.run(

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1095,7 +1095,7 @@ class NoiseInversion(Inversion):
         # task usually fails due to timeout when `tasktime` is set for an 
         # adjoint simulation (tasktime=self.system.tasktime * 2)
         self.system.run([generate_event_kernels], single=True, 
-                        tasktime=self.system.tasktime * 1)
+                        tasktime=self.system.tasktime * 4)
 
         # Now the original function takes over and combines event kernels into
         # a misfit kernel, and applies smoothing, masking, etc.

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -538,7 +538,7 @@ class NoiseInversion(Inversion):
             # We need to load in ZZ synthetics so that they are discoverable
             # by the misfit evaluation
             unix.rm(self.trace_path(tag="syn"))
-            unix.cp(src=self.trace_path(tag="syn", force=self._force), 
+            unix.cp(src=self.trace_path(tag="syn", comp=self._force), 
                     dst=self.trace_path(tag="syn")
                     )
 

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -446,7 +446,7 @@ class NoiseInversion(Inversion):
         """
         # If we are the middle of a thrifty inversion, simply load the misfit
         # of the last accepted line search evaluation
-        if self.thrifty and self._thrifty_status:
+        if self.is_thrifty:
             total_misfit = self.optimize.load_vector(name="f_new")
             logger.info(f"total misfit `f_new` ({self.evaluation}) = "
                         f"{total_misfit:.2E}")

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -1130,7 +1130,12 @@ class NoiseInversion(Inversion):
 
             # Set up for the current forward simulation
             self._force = force
-
+            # If we are running a thrifty inversion we need to save the fwd
+            # arrays so that the next iterations adjoint simulations can use 'em
+            if self.is_thrifty:
+                save_forward_arrays = self.fwd_arr_path
+            else:
+                save_forward_arrays = False
 
             logger.info(msg.sub(f"MISFIT EVALUATION FOR FORCE '{self._force}'"))
             self.system.run(
@@ -1142,6 +1147,7 @@ class NoiseInversion(Inversion):
                 save_residuals=os.path.join(
                     self.path.eval_func, "residuals",
                     f"residuals_{{src}}_{self.evaluation}_{tag}.txt"),
+                save_forward_arrays=save_forward_arrays,
                 components=components
             )
             self._rename_preprocess_files(tag)

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -535,14 +535,22 @@ class NoiseInversion(Inversion):
         # Z component force behaves like a normal workflow, except that we only
         # create adjoint sources for the Z component (E, N will be 0's)
         if self._force == "Z":
+            # We need to load in ZZ synthetics so that they are discoverable
+            # by the misfit evaluation
+            unix.rm(self.trace_path(tag="syn"))
+            unix.cp(src=self.trace_path(tag="syn", force=self._force), 
+                    dst=self.trace_path(tag="syn")
+                    )
+
             # e.g., scratch/solver/001/traces/adj_zz/*.adj
             save_adjsrcs = os.path.join(
                 self.solver.cwd, "traces", 
                 f"adj_{self._force.lower()}{self._cmpnt.lower()}"
                 )
             super().evaluate_objective_function(save_residuals=save_residuals, 
-                                                components=["Z"], 
-                                                save_adjsrcs=save_adjsrcs)
+                                                save_adjsrcs=save_adjsrcs,
+                                                components=["Z"]
+                                                )
             
         # Run E and N misfit quantification
         else:

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -364,11 +364,14 @@ class NoiseInversion(Inversion):
         if ("RR" not in self.kernels) and ("TT" not in self.kernels):
             logger.info("RR, TT not specified in parameter 'kernels'. Skipping")
             return 
-        
-        if self.separate_rt_kernels:
-            self._run_rt_adjoint_simulations_separate()
-        else:
-            self._run_rt_adjoint_simulations_combined()
+
+        self._run_rt_adjoint_simulations_separate()
+
+        # COMMENTED OUT UNTIL THIS FUNCTIONALITY IS WRITTEN
+        # if self.separate_rt_kernels:
+        #     self._run_rt_adjoint_simulations_separate()
+        # else:
+        #     self._run_rt_adjoint_simulations_combined()
 
         # Unset internal tracking variables for safety
         self._force = None

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -385,8 +385,6 @@ class NoiseInversion(Inversion):
         """
         # Four possible adjoint simulations: ER, NR, ET, NT
         for force in ["E", "N"]:
-            # e.g., E_FWD_ARR (for E component force)
-            load_forward_arrays = f"{force}_FWD_ARR"
             for cmpnt in ["R", "T"]:
                 # Don't run a simulation if we don't need the kernels
                 if cmpnt not in self.kernels:
@@ -1186,3 +1184,5 @@ class NoiseInversion(Inversion):
         # Reset states incase we need to run again
         for force in cfg.keys():
             self._states[f"evaluate_line_search_misfit_{force}"] = 0
+        self.checkpoint()
+


### PR DESCRIPTION
Previously `Thrifty` mode (where line search results from iteration I are used to replace the forward simulations of iteration I + 1) was not properly implemented into the NoiseInversion workflow. This PR improves that functionality and also adds some QoL features and fixes:

## ChangeLog

### Major
- **New parameter**: `optimize.step_len_min` allows the User to set a minimum step length (alpha) as a percentage of the model values. This prevents line searches from trying to minimize misfit with very small model changes, which is a waste of computational resources. 
- **Changed Behavior**: Saved Forward arrays are now overwritten by new forward simulations, for the case when Thrifty line searches need access to forward arrays in subsequent adjoint simulations
- **QoL Improvement**: Initial and True model file export (tied to parameter `export_model`) now checks whether files exist and will not overwrite (previously they always overwrote), meaning Solver.setup() is now a lot faster
- **Bugfix**: Preprocess.Pyaflowa was missing a `mkdir` for adjoint source directory which was leading to FileNotFoundError
- **Examples**: Changed starting step length in Ex1 to achieve successful line search. Ex2 does NOT finish iteration, will need to fix this

### Minor
- Workflow Thrifty checks are now inside a property that can be checked, rather than as a function call
- Preprocess reads STATION metadata (locations) from it's Event's own 'DATA' directory (e.g., scratch/solver/001/DATA/STATIONS), rather than from the master station file (e.g., path_specfem_data/STATIONS), allowing for different STATION definitions for different events. Untested, might need a little more tooling to make that work.
- New internal Workflow.Inversion attribute `_was_thrifty` keeps track of whether a previous iteration's finalization was done in a Thrifty manner, allowing the current iteration to skip forward simulations. **WARNING** This parameter is NOT saved to disk, so if the workflow breaks between finalization of iteration I and forward simulations of I+1, then forward simulations will be run like a normal inversion.
- Cleaned up the aesthetic look of Submit and Debug commands
- Removed `step_len_max` from Line Search instantiation because it was not used by the module
- Refactored some optimization checks for `step_len_min` and `step_len_max` with better log messages and less redundant code
- Removed `path_specfem_data` from Preprocess init because it is not used in the module
- Removed some redundant checks from Preprocess (Default and Pyaflowa)
- Removed STATION file reading from default preprocessing as the Inventory was not used




