### PR TITLE
Bugfix System Fujitsu/Wisteria environs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v3.2.3 (#218)
+- Bugfix Fujitsu/Wisteria environ variable was being updated internally, causing an accumulating error
+- Removed Pyaflowa preprocess normalization step as this was hardcoded for some research tasks, not meant to be in code
+- Added a tasktime multiplier to Inversion kernel postprocessing tasks, eventually this should be accessible via the State system or parameter file but for now making it part of the source code
+- Removes main install instruction pointing to Pyatoa GitHub, points to PyPi now by default
+- Updates [dev] install instructions to point towards GitHub rather than PyPi versions. Dev install instructions are now:
+  ```bash
+  pip install -e .[dev]  # to install dev branches 
+  ```
+
+## v3.2.2 
+- Hotfix: update cli tool 'plotst' to reflect import structure changes 
+
 ## v3.2.1 (#214)
 - Model class now saves internal model representation as 'object' arrays to deal with chunks of differing lengths
 - Model .npz files are now saved as pickle files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "ipython", "ipdb"]
+dev = [
+	"pytest", 
+    "pyatoa @ git+https://github.com/adjtomo/pyatoa.git@devel",
+    "pysep-adjtomo @ git+https://github.com/adjtomo/pysep.git@devel"
+]
 
 [project.urls]
 homepage = "https://github.com/adjtomo/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.2"
+version = "3.2.3"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -19,8 +19,7 @@ dependencies = [
     "pypdf",
     "IPython",
     "dill",
-    #"pyatoa>=0.4.0",
-    "pyatoa @ git+https://github.com/adjtomo/pyatoa.git@devel",
+    "pyatoa>=0.4.0",
     "pysep-adjtomo",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-	"pytest", 
+    "pytest", 
     "pyatoa @ git+https://github.com/adjtomo/pyatoa.git@devel",
     "pysep-adjtomo @ git+https://github.com/adjtomo/pysep.git@devel"
 ]

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -525,8 +525,7 @@ class Pyaflowa:
             st_syn_raw = mgmt.st_syn.copy()
 
             # Filter waveforms
-            # !!! HARDCODE NORMALIZATION FOR ANAT, REMOVE THIS !!!
-            mgmt.preprocess(remove_response=False, normalize_to="syn")
+            mgmt.preprocess(remove_response=False)
             if fix_windows:
                 # Determine components from waveforms on the fly so that we can
                 # use that information to only select windows we need

--- a/seisflows/system/fujitsu.py
+++ b/seisflows/system/fujitsu.py
@@ -252,7 +252,9 @@ class Fujitsu(Cluster):
 
         # If no environs, ensure there is not trailing comma
         if self.environs:
-            self.environs = f",{self.environs}"
+            environs = f",{self.environs}"
+        else:
+            environs = ""
 
         # Default Fujitsu command line input, can be overloaded by subclasses
         # Copy-paste this default run_call and adjust accordingly for subclass
@@ -265,7 +267,7 @@ class Fujitsu(Cluster):
                 # Ensure that these are comma-separated, not space-separated
                 f"-x SEISFLOWS_FUNCS={funcs_fid},"  
                 f"SEISFLOWS_KWARGS={kwargs_fid},"
-                f"SEISFLOWS_TASKID={taskid}{self.environs},"
+                f"SEISFLOWS_TASKID={taskid}{environs},"
                 f"GPU_MODE={int(bool(self.gpu))}",  # 0 if False, 1 if True
                 f"{self.run_functions}",
             ])

--- a/seisflows/workflow/migration.py
+++ b/seisflows/workflow/migration.py
@@ -273,8 +273,12 @@ class Migration(Forward):
             if os.path.exists(scratch_path):
                 shutil.rmtree(scratch_path)
 
+        # NOTE: May need to increase the tasktime by a factor of n because the
+        # smoothing operation is computational expensive; add the following:
+        # tasktime=self.system.tasktime * 2  # increase 2 if you need more time
         self.system.run([mask_source_event_kernels, combine_event_kernels, 
-                         smooth_misfit_kernel], single=True)
+                         smooth_misfit_kernel], single=True,
+                         tasktime=self.system.tasktime * 2)
 
     def evaluate_gradient_from_kernels(self):
         """


### PR DESCRIPTION
Small update to fix a bug in Wisteria system module that accumulated a ',' in the environment variables so that the second time `system.run` was called it would lead to an error. Some small additional riders are included.

### Changelog:
- Bugfix Fujitsu/Wisteria environ variable was being updated internally, causing an accumulating error
- Bugfix: Removed Pyaflowa preprocess normalization step as this was hardcoded for some personal research tasks, not meant to be in code
- Added a tasktime multiplier to Inversion kernel postprocessing tasks, eventually this should be accessible via the State system or parameter file but for now making it part of the source code
- Removes main install instruction pointing to Pyatoa GitHub, points to PyPi now by default
- Updates [dev] install instructions to point towards GitHub rather than PyPi versions. Dev install instructions are now:
  ```bash
  pip install -e .[dev]  # to install dev branches 
  ```

