### PR TITLE
Fixes 'generate_data' option for noise inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.2.4 (#221)
+- Fixes synthetic inversion data generation for noise inversion workflow
+- Fixes some flag misnaming in Forward workflow synthetic inversion data generation
+- Adjusts main log message aesthetics to provide a visual marker for new job submissions
+
 ## v3.2.3 (#218)
 - Bugfix Fujitsu/Wisteria environ variable was being updated internally, causing an accumulating error
 - Removed Pyaflowa preprocess normalization step as this was hardcoded for some research tasks, not meant to be in code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.3"
+version = "3.2.4"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -166,7 +166,7 @@ class Specfem:
         self._ext = ""  # for database file extensions
 
         # Define available choices for check parameters
-        self._available_model_types = ["gll", "custom_gll"]
+        self._available_model_types = ["gll", "custom_gll", "custom_1d_gll"]
         self._available_materials = [
             "ELASTIC", "ACOUSTIC",  # specfem2d, specfem3d
             "ISOTROPIC", "ANISOTROPIC"  # specfem3d_globe

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -166,7 +166,7 @@ class Specfem:
         self._ext = ""  # for database file extensions
 
         # Define available choices for check parameters
-        self._available_model_types = ["gll", "custom_gll", "custom_1d_gll"]
+        self._available_model_types = ["gll"]
         self._available_materials = [
             "ELASTIC", "ACOUSTIC",  # specfem2d, specfem3d
             "ISOTROPIC", "ANISOTROPIC"  # specfem3d_globe

--- a/seisflows/system/cluster.py
+++ b/seisflows/system/cluster.py
@@ -148,7 +148,7 @@ class Cluster(Workstation):
         # Determine where submit call will be sent (login or compute node)
         if direct:
             header = ""
-            print("submitting master job directly to login node")
+            print("submit 'SeisFlows Main Job' directly to cluster login node")
         else:
             header = self.submit_call_header
 

--- a/seisflows/system/cluster.py
+++ b/seisflows/system/cluster.py
@@ -123,6 +123,11 @@ class Cluster(Workstation):
         Submits the main workflow job as a separate job submitted directly to
         the system that is running the master job
 
+        .. note::
+
+            print statements are used rather than log statements because the
+            logger will not yet have been instantiated
+
         :type workdir: str
         :param workdir: path to the current working directory
         :type parameter_file: str
@@ -135,8 +140,6 @@ class Cluster(Workstation):
             be discouraged by sys admins as some  array processing will take 
             place on the shared login node. 
         """
-        logger.info(msg.mjr("SEISFLOWS SUBMIT", char="%"))
-
         # Copy log files if present to avoid overwriting
         for src in [self.path.output_log, self.path.par_file]:
             if os.path.exists(src) and os.path.exists(self.path.log_files):
@@ -145,7 +148,7 @@ class Cluster(Workstation):
         # Determine where submit call will be sent (login or compute node)
         if direct:
             header = ""
-            logger.info("submitting master job directly to login node")
+            print("submitting master job directly to login node")
         else:
             header = self.submit_call_header
 
@@ -161,7 +164,7 @@ class Cluster(Workstation):
         try:
             subprocess.run(submit_call, shell=True)
         except subprocess.CalledProcessError as e:
-            logger.critical(f"SeisFlows master job has failed with: {e}")
+            print(f"SeisFlows master job has failed with: {e}")
             sys.exit(-1)
 
     def run(self, funcs, single=False, tasktime=None, _retry=0, **kwargs):

--- a/seisflows/system/runscripts/submit_workflow.py
+++ b/seisflows/system/runscripts/submit_workflow.py
@@ -17,6 +17,8 @@ a script using subprocess, allowing it to be submitted to e.g., a job scheduler
 """
 import os
 import argparse
+from seisflows import logger
+from seisflows.tools import msg
 from seisflows.tools.config import import_seisflows
 
 
@@ -36,12 +38,14 @@ def parse_args():
 
 if __name__ == '__main__':
     """
-    Submit workflow.main() as a MASTER JOB on the compute system
+    Submit workflow.main() as a MASTER JOB on the compute system.
     """
     args = parse_args()
     workflow = import_seisflows(workdir=args.workdir,
                                 parameter_file=args.parameter_file,
                                 stream_handler=False)
+
+    logger.info(msg.mjr("SEISFLOWS SUBMIT", char="%"))
     workflow.check()
     workflow.setup()
     workflow.run()

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -345,7 +345,8 @@ class Forward:
         # Run forward simulation with solver
         self.run_forward_simulations(
             path_model=path_model, export_traces=None,  
-            save_traces=save_traces, save_forward=False
+            save_traces=save_traces, save_forward_arrays=False,
+            flag_save_forward=False
             )
         
         # Symlink data into solver directories so it can be found by preprocess

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -297,7 +297,7 @@ class NoiseInversion(Inversion):
 
         for force in forces:
             self._force = force
-            logger.info(f"running forward simulations for force: {self._force}")
+            logger.info(msg.sub(f"FORWARD SIMULATION FORCE '{self._force}'"))
             self.system.run([self._generate_synthetic_data_single], **kwargs)
 
     def _generate_synthetic_data_single(self, path_model=None, **kwargs):

--- a/seisflows/workflow/noise_inversion.py
+++ b/seisflows/workflow/noise_inversion.py
@@ -218,7 +218,8 @@ class NoiseInversion(Inversion):
         :rtype: list
         :return: list of methods to call in order during a workflow
         """
-        return [self.evaluate_zz_misfit,
+        return [self.generate_synthetic_data,
+                self.evaluate_zz_misfit,
                 self.run_zz_adjoint_simulations,
                 self.evaluate_rt_misfit,
                 self.run_rt_adjoint_simulations,
@@ -267,6 +268,89 @@ class NoiseInversion(Inversion):
         which is set by calling functions.
         """
         return f"{self._force}_FWD_ARR"
+    
+    def generate_synthetic_data(self, **kwargs):
+        """
+        Function Overwrite of `workflow.forward.generate_synthetic_data()` 
+        To allow generation of both vertical and horizontal component SGF data
+
+        For synthetic inversion cases, we can use the workflow machinery to
+        generate 'data' by running simulations through a target/true model for 
+        each of our `ntask` sources. This only needs to be run once during a 
+        workflow.
+        """
+        forces = []
+        if "ZZ" in self.kernels:
+            forces.append("Z")
+        elif "RR" in self.kernels or "TT" in self.kernels:
+            forces.append("E")  # E must come first
+            forces.append("N")
+
+        # Check the target model that will be used to generate data
+        logger.info("checking true/target model parameters:")
+        self.solver.check_model_values(path=self.path.model_true)
+
+        for force in forces:
+            self._force = force
+            self.system.run([self._generate_synthetic_data_single], **kwargs)
+
+    def _generate_synthetic_data_single(self, path_model=None, **kwargs):
+        """
+        Function Overwrite of `workflow.forward.generate_synthetic_data()` 
+        To account for specific naming schema of the synthetic data and trace
+        rotation of the horizontal components. Runs forward simulations for
+        Z, N and E components and generates ZZ, RR and TT synthetic data 
+        (dependent on values for parameter `kernels`). Data are stored in
+        `path_data/{source_name}/{kernel}/*` so that they are discoverable
+        by the preprocessing module at a later stage.
+        """
+        # Set default argument. Allow User to generate synthetics through
+        # a model other than true, but default to true model
+        path_model = path_model or self.path.model_true
+
+        # Saves to scratch/solver/traces/obs_{force}/*
+        save_traces = self.trace_path(tag="obs", comp=self._force)
+
+        # Run forward simulation with solver
+        self.run_forward_simulations(
+            path_model=path_model, export_traces=None,  
+            save_traces=save_traces, save_forward_arrays=False,
+            flag_save_forward=False
+            )
+        
+        # Move generated data into the `path_data` directory with the correct 
+        # sub-directory naming, same as we do in forward simulations
+        if self._force == "E":
+            logger.info("waiting for 'N' forward sim. for data generation")
+            return
+        elif self._force == "N":
+            # Rotate ER, ET, NR, NT to RR and TT waveforms. Rotated data are
+            # saved directly in the `traces/obs` directory
+            self.rotate_ne_traces_to_rt(tag="obs")
+            src = os.path.join(self.trace_path(tag="obs"), "*")
+            # Sort of hacky but we need to know what component the waveforms
+            # are in so we check the filename so we can save it in the correct
+            # place
+            for src_ in glob(src):
+                # NN.SSS.?XR.sem?*
+                net, sta, cha, *_ = os.path.basename(src_).split(".")
+                comp = cha[-1]  # should be 'R' or 'T'
+                dst = os.path.join(
+                    self.path.data, self.solver.source_name, f"{comp}{comp}"
+                    )
+                unix.mv(src_, dst)
+            # Remove directories that contain pre-rotated traces
+            unix.rm(self.trace_path(tag="obs", comp="E"))
+            unix.rm(self.trace_path(tag="obs", comp="N"))
+        elif self._force == "Z":
+            src = os.path.join(save_traces, "*")
+            dst = os.path.join(self.path.data, self.solver.source_name, "ZZ")
+            for src_ in glob(src):
+                # Move the data directly, it will be symlinked back during
+                # `prepare_data_for_solver`
+                unix.mv(src_, dst)
+            # Delete the now empty directory to keep things clean for later
+            unix.rm(save_traces)
 
     def evaluate_zz_misfit(self, **kwargs):
         """
@@ -630,14 +714,14 @@ class NoiseInversion(Inversion):
         with ProcessPoolExecutor(max_workers=unix.nproc()) as executor:
             futures = [
                 executor.submit(self._rotate_ne_trace_to_rt_single,
-                                f_ee, f_ne, f_en, f_nn)
+                                f_ee, f_ne, f_en, f_nn, tag)
                 for f_ee, f_ne, f_en, f_nn in zip(fids_ee, fids_ne,
                                                   fids_en, fids_nn)
                 ]
         # Simply wait until this task is completed because its just file writing
         wait(futures)
 
-    def _rotate_ne_trace_to_rt_single(self, f_ee, f_ne, f_en, f_nn):
+    def _rotate_ne_trace_to_rt_single(self, f_ee, f_ne, f_en, f_nn, tag="syn"):
         """
         Parallalizable private function to rotate NE synthetics to RR and TT
 
@@ -654,6 +738,11 @@ class NoiseInversion(Inversion):
         :param f_en: path to the EN synthetic waveform (E force, N component)
         :type f_nn: str
         :param f_nn: path to the NN synthetic waveform (N force, N component)
+        :type tag: str
+        :param tag: where to look for waveform data within the scratch dir.
+            Example path is: scratch/solver/<source_name>/traces/<tag>_?/*
+            Tag by default is 'syn' but can also be 'obs' for generating
+            synthetic data
         """
         src_name = self.solver.source_name
 
@@ -682,16 +771,16 @@ class NoiseInversion(Inversion):
 
         # Write TT/RR synthetics back to the main synthetic trace directory
         if "TT" in self.kernels:
-            # scratch/solver/{source_name}/traces/syn/NN.SSS.?XT.sem?*
+            # scratch/solver/{source_name}/traces/{tag}/NN.SSS.?XT.sem?*
             fid_t = f"{net}.{sta}.{cha[:2]}T.{ext}"
             write(st=Stream(tr_tt), 
-                  fid=os.path.join(self.trace_path(tag="syn"), fid_t),
+                  fid=os.path.join(self.trace_path(tag=tag), fid_t),
                   data_format=self.solver.syn_data_format)
         if "RR" in self.kernels:
-            # scratch/solver/{source_name}/traces/syn/NN.SSS.?XR.sem?*
+            # scratch/solver/{source_name}/traces/{tag}/NN.SSS.?XR.sem?*
             fid_r = f"{net}.{sta}.{cha[:2]}R.{ext}"
             write(st=Stream(tr_rr), 
-                  fid=os.path.join(self.trace_path(tag="syn"), fid_r),
+                  fid=os.path.join(self.trace_path(tag=tag), fid_r),
                   data_format=self.solver.syn_data_format)
 
     def rotate_rt_adjsrcs_to_ne(self, choice):


### PR DESCRIPTION
Only relevant for 'noise_inversion' workflows. The `generate_data` option which runs forward simulations through the target model ('path_model_true') was not implemented for the 'noise_inversion' workflow. This PR implements that functionality and allows generation of ZZ, RR and TT synthetic greens functions that can be used as 'observed' data for a synthetic inversion. Simply setting the parameter `generate_data`==True in the parameter file will implement this option. Some additional aesthetic riders.

## Changelog
- Fixes synthetic inversion data generation for noise inversion workflow
- Fixes some flag misnaming in Forward workflow synthetic inversion data generation
- Adjusts main log message aesthetics to provide a visual marker for new job submissions 