### PR TITLE
Bugfix Pyaflowa finalization tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.2.5 (#222)
+- Fixes logs and figures getting deleted but not saved during Pyaflowa finalization
+- Changes finalization behavior to not delete logs/figures from scratch directory, if User requests no export
+- Removes hardcoded tasktime increase for postprocessing tasks which was accidentally left in from development
+
 ## v3.2.4 (#221)
 - Fixes synthetic inversion data generation for noise inversion workflow
 - Fixes some flag misnaming in Forward workflow synthetic inversion data generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.4"
+version = "3.2.5"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -625,9 +625,9 @@ class Pyaflowa:
         if self.plot_waveforms and self.export_figures:
             # Determine the available evaluation tags
             evaluations = []
-            # Expected fmt: <source_name>_<evaluation><tag>.pdf
+            # Expected fmt: <source_name>_<evaluation>_<tag>.pdf
             for fid in glob(os.path.join(self.path._figures, "*_i??s??*.pdf")):
-                for part in os.path.basename(fid).split("_"):
+                for part in os.path.basename(fid).split(".")[0].split("_"):
                     # Slightly hacky, expecting that eval is the only tag in the
                     # filename that matches the format i?????
                     if part.startswith("i") and len(part) == 6:  # i??s??
@@ -651,9 +651,9 @@ class Pyaflowa:
         if self.export_log_files:
             # Determine the available evaluation tags
             evaluations = []
-            # Expected fmt: <source_name>_<evaluation><tag>.log
+            # Expected fmt: <source_name>_<evaluation>_<tag>.log
             for fid in glob(os.path.join(self.path._logs, "*_i??s??*.log")):
-                for part in os.path.basename(fid).split("_"):
+                for part in os.path.basename(fid).split(".")[0].split("_"):
                     # Slightly hacky, expecting that eval is the only tag in the
                     # filename that matches the format i?????
                     if part.startswith("i") and len(part) == 6:  # i??s??

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -647,6 +647,10 @@ class Pyaflowa:
             unix.mkdir(dst)
             unix.mv(src, dst)
 
+            # Bomb out the scratch directory since we exported
+            unix.rm(self.path._figures)
+            unix.mkdir(self.path._figures)
+
         # Save log files to output (if requested)
         if self.export_log_files:
             # Determine the available evaluation tags
@@ -672,14 +676,10 @@ class Pyaflowa:
             unix.mkdir(dst)
             unix.mv(src, dst)
 
-        # Bomb out the scratch directory regardless of export status
-        unix.rm(self.path._figures)
-        unix.mkdir(self.path._figures)
-
-        # Bomb out the log files regardless of export status
-        unix.rm(self.path._logs)
-        unix.mkdir(self.path._logs)
-        unix.mkdir(os.path.join(self.path._logs, "tmp"))
+            # Bomb out the log files scratch directory since we exported
+            unix.rm(self.path._logs)
+            unix.mkdir(self.path._logs)
+            unix.mkdir(os.path.join(self.path._logs, "tmp"))
 
     def _check_fixed_windows(self, iteration, step_count):
         """

--- a/seisflows/workflow/migration.py
+++ b/seisflows/workflow/migration.py
@@ -278,7 +278,7 @@ class Migration(Forward):
         # tasktime=self.system.tasktime * 2  # increase 2 if you need more time
         self.system.run([mask_source_event_kernels, combine_event_kernels, 
                          smooth_misfit_kernel], single=True,
-                         tasktime=self.system.tasktime * 2)
+                         tasktime=self.system.tasktime * 1)
 
     def evaluate_gradient_from_kernels(self):
         """


### PR DESCRIPTION
Small update that bug fixes finalization for Pyaflowa preprocessing module.

@aakash10gupta pointed out that figures/logs were being deleted during the finalization task when using the Pyaflowa preprocessing module. This was due to a change that tried to accommodate additional tags on the figures and log files necessary for the noise inversion workflows, which ended up breaking for normal inversion workflows.

# Changelog
- Fixes logs and figures getting deleted but not saved during Pyaflowa finalization
- Changes finalization behavior to not delete logs/figures from scratch directory, if User requests no export
- Removes hardcoded tasktime increase for postprocessing tasks which was accidentally left in from development