### PR TITLE
Improve Pyaflowa error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v3.2.6 (#223)
+- Adds better traceback information when Pyaflowa preprocessing tasks fail
+
 ## v3.2.5 (#222)
 - Fixes logs and figures getting deleted but not saved during Pyaflowa finalization
 - Changes finalization behavior to not delete logs/figures from scratch directory, if User requests no export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.5"
+version = "3.2.6"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -8,6 +8,7 @@ import os
 import sys
 import logging
 import time
+import traceback
 import random
 import numpy as np
 from concurrent.futures import ProcessPoolExecutor, wait

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -554,7 +554,10 @@ class Pyaflowa:
                 mgmt.window()
             mgmt.measure()
         except Exception as e:
-            station_logger.critical(f"FLOW FAILED: {e}")
+            station_logger.critical(f"FLOW FAILED:")
+            # Get the full traceback and push to logger
+            exc_str = traceback.format_exc()
+            station_logger.critical(exc_str)
             pass
 
         # Plot waveform + map figure. Map may fail if we don't have appropriate


### PR DESCRIPTION
Adds better traceback information when preprocessing fails with Pyaflowa preprocess module, before it was too generic and had no traceback information so it was impossible to determine where errors were occurring.