### PR TITLE
Improves System sub-class Wisteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v3.3.0 (#227)
+- Updates for System class Wisteria
+- Overhauled `Fujitsu` System class to now allow parameter `ntask_max`. This is not an inherent option in Fujitsu-brand clusters so I needed to code it up directly in SeisFlows. General architecture is that SeisFlows submits `ntask_max` jobs to the System and monitors them, whenever a job completes, a new job is submitted to take its place, until `ntask` jobs have completed.
+- Replace some default module loading in Wisteria custom run scripts to not use CUDA-aware MPI as this is not used in SPECFEM3D_Cartesian
+- Shifted `residuals` directory creation into the responsibility of Workflow module, rather than preprocessing module, to keep dir. creation high-level
+- Bugfix: Default preprocessing was not correctly attributing event origin time to synthetics which causes waveform timing mismatch when using real data (this was okay for synthetics because they both then had default timing)
+- Bugfix: SPECFEM solver `nproc` check because there is a case where mpiexec gets defined to a default value for the system (if assigned NoneType), leading to serial runs when the User is expecting MPI processes. This is a redundant check to the System check
+- Preprocessing modules (both Default and Pyaflowa) improved error logging
+- Renamed log files for individual solver directories for `xgenerate_databases` as these were the same as the mesher (mesher -> database)
+
 ## v3.2.10
 - Hotfix: system Chinook was only using 1 core for single jobs which is not enough for combine_sem and smooth operations (but okay for xcombine_vol_data_vtk)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.10"
+version = "3.3.0"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.2.8"
+version = "3.2.9"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -414,17 +414,16 @@ class Default:
                     # Uncomment if you want more extensive debug info
                     # exc_str = traceback.format_exc()
                     # logger.critical(exc_str)
+                    sys.exit(-1)
 
         # Write residuals to text file for other modules to find
         if save_residuals:
-            unix.mkdir(os.path.dirname(save_residuals)) 
             with open(save_residuals, "a") as f:
                 for residual in residuals:
                     f.write(f"{residual:.2E}\n")
 
             # Exporting residuals to disk (output/) for more permanent storage
             if export_residuals:
-                unix.mkdir(export_residuals)
                 unix.cp(src=save_residuals, dst=export_residuals)
 
         logger.info(f"FINISH QUANTIFY MISFIT: {source_name}")

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -410,13 +410,14 @@ class Default:
                     residual = future.result()
                     residuals.append(residual)
                 except Exception as e:
-                    logger.critical(f"PREPROC FAILED:")
-                    exc_str = traceback.format_exc()
-                    logger.critical(exc_str)
-                    sys.exit(-1)
+                    logger.critical(f"PREPROC FAILED: {e}")
+                    # Uncomment if you want more extensive debug info
+                    # exc_str = traceback.format_exc()
+                    # logger.critical(exc_str)
 
         # Write residuals to text file for other modules to find
         if save_residuals:
+            unix.mkdir(os.path.dirname(save_residuals)) 
             with open(save_residuals, "a") as f:
                 for residual in residuals:
                     f.write(f"{residual:.2E}\n")
@@ -491,8 +492,8 @@ class Default:
         # Determine origintime of synthetic event, will ONLY be used if 
         # `*_data_format` == 'ASCII'
         source_fid = os.path.join(self.path.solver, source_name,
-                                  "DATA", self._source_prefix)
-        cat = read_events_plus(fid=source_fid, format=self._source_prefix)
+                                  "DATA", self.source_prefix)
+        cat = read_events_plus(fid=source_fid, format=self.source_prefix)
 
         # Read in waveforms based on the User-defined format(s)
         # `origintime` will only be applied if format=='ASCII'
@@ -500,6 +501,9 @@ class Default:
                    origintime=cat[0].preferred_origin().time)
         syn = read(fid=syn_fid, data_format=self.syn_data_format,
                    origintime=cat[0].preferred_origin().time)
+
+
+        logger.info(f"PREPROCESSING {syn[0].get_id()}")
 
         # Wrap all the preprocessing functions into single function so that
         # it can be more easily overwritten by overwriting classes

--- a/seisflows/preprocess/default.py
+++ b/seisflows/preprocess/default.py
@@ -408,7 +408,9 @@ class Default:
                     residual = future.result()
                     residuals.append(residual)
                 except Exception as e:
-                    logger.critical(f"PREPROC FAILED: {e}")
+                    logger.critical(f"PREPROC FAILED:")
+                    exc_str = traceback.format_exc()
+                    logger.critical(exc_str)
                     sys.exit(-1)
 
         # Write residuals to text file for other modules to find

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -21,7 +21,7 @@ from pysep.utils.io import read_events_plus, read_stations
 from seisflows import logger
 from seisflows.tools import unix
 from seisflows.tools.config import Dict
-from seisflows.tools.graphics import imgs_to_pdf, merge_pdfs
+from seisflows.tools.graphics import imgs_to_pdf
 from seisflows.tools.specfem import return_matching_waveform_files
 from seisflows.preprocess.default import read, initialize_adjoint_traces
 
@@ -363,7 +363,6 @@ class Pyaflowa:
         # Slightly different than Default preprocessing because we need to
         # normalize by the total number of windows
         if save_residuals:
-            unix.mkdir(os.path.dirname(save_residuals)) 
             # Normalize the raw misfit by the number of measurements
             if total_windows != 0:
                 summed_misfit = total_misfit / total_windows
@@ -374,7 +373,6 @@ class Pyaflowa:
             with open(save_residuals, "w") as f:
                 f.write(f"{summed_misfit:.2E}\n")
             if export_residuals:
-                unix.mkdir(export_residuals)
                 unix.cp(src=save_residuals, dst=export_residuals)
 
         # Combine all the individual .png files created into a single PDF for

--- a/seisflows/preprocess/pyaflowa.py
+++ b/seisflows/preprocess/pyaflowa.py
@@ -363,6 +363,7 @@ class Pyaflowa:
         # Slightly different than Default preprocessing because we need to
         # normalize by the total number of windows
         if save_residuals:
+            unix.mkdir(os.path.dirname(save_residuals)) 
             # Normalize the raw misfit by the number of measurements
             if total_windows != 0:
                 summed_misfit = total_misfit / total_windows

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -1121,8 +1121,8 @@ class SeisFlows:
             items=[
                 "'seisflows examples <name_or_idx>': print example description",
                 "'seisflows examples setup <name_or_idx>': setup example but "
-                "don't run workflow 'seisflows examples run <name_or_idx>': "
-                "setup and run example"
+                "don't run workflow ",
+                "'seisflows examples run <name_or_idx>': setup and run example"
             ],
             header="seisflows examples"
         ))

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -213,6 +213,15 @@ class Specfem:
                 f"SeisFlows solver module"
             )
 
+        # Make sure mpiexec is defined. We can get into a tricky situation where 
+        # mpiexec gets default defined by System but is not defined for solver
+        # leading to binaries getting unexpectedly run in serial mode 
+        if self.nproc > 1:
+            assert(self._mpiexec is not None), (
+                f"Multi-core workflows (`nproc`>1) require an MPI executable "
+                f"`mpiexec`"
+            ) 
+
         # Check that SPECFEM/DATA directory exists
         assert(self.path.specfem_data is not None and
                os.path.exists(self.path.specfem_data)), (

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -983,7 +983,7 @@ class Specfem:
         :return: logfile name that matches executable name
         """
         convert_dict = {"specfem": "solver", "meshfem": "mesher",
-                        "generate_databases": "mesher", "smooth": "smooth",
+                        "generate_databases": "database", "smooth": "smooth",
                         "combine": "combine"}
         for key, val in convert_dict.items():
             if key in exc:

--- a/seisflows/system/fujitsu.py
+++ b/seisflows/system/fujitsu.py
@@ -301,7 +301,6 @@ class Fujitsu(Cluster):
             # Used to track how many jobs completed each batch
             jobs_pending = len(job_ids)
             start += nsubmit  # increment for next loop
-            logger.debug(f"new start {start}")
             if start >= _ntask:
                 complete_all = True  # last batch
 
@@ -324,7 +323,6 @@ class Fujitsu(Cluster):
             else:
                 # Set up for the next round of job submissions
                 completed += jobs_pending- len(job_ids)
-                logger.debug(f"{completed} jobs completed, submit new batch")
 
     def monitor_job_status(self, job_id, timeout_s=300, wait_time_s=15, 
                            complete_all=False):
@@ -406,7 +404,6 @@ class Fujitsu(Cluster):
             for jid, state in zip(job_ids[:], states[:]):
                 # Check for completed jobs 
                 if state in self._completed_states:
-                    logger.debug(f"{jid} completed")
                     job_ids.remove(jid)
                 # Let the User know that a job has failed 
                 elif state in self._failed_states:    
@@ -475,7 +472,6 @@ class Fujitsu(Cluster):
             by putting a stop criteria
         :raises TimeoutError: if 'pjstat' does not return any output for ~1 min.
         """
-        logger.debug(f"querying job ID {job_id}")
         job_ids, job_states = [], []
 
         # Look at currently running jobs as well as completed jobs

--- a/seisflows/system/fujitsu.py
+++ b/seisflows/system/fujitsu.py
@@ -426,7 +426,10 @@ class Fujitsu(Cluster):
             # submit more to the queue. Except for `complete_all` which triggers
             # last batch and we wait for all job IDs to finish
             if complete_all:
-                continue
+                if job_ids:
+                    continue
+                else:
+                    return
             elif ntrack != len(job_ids):
                 return job_ids   
 

--- a/seisflows/system/runscripts/custom_run-wisteria
+++ b/seisflows/system/runscripts/custom_run-wisteria
@@ -22,7 +22,7 @@ if [ $GPU_MODE -eq 1 ]; then  # Use GPUs
 	echo "loading GPU modules on compute node"
     module load cuda/12.2
     module load gcc
-    module load ompi-cuda
+    module load ompi
 else
 	echo "loading CPU modules on compute node"
     module load intel

--- a/seisflows/system/wisteria.py
+++ b/seisflows/system/wisteria.py
@@ -100,16 +100,3 @@ class Wisteria(Fujitsu):
                 "share-debug": 1, "share-short": 2, "share": 5
                 }
 
-    @property
-    def run_call_header(self):
-        """Override run call header to allow for GPU version requirements"""
-        if self.gpu:
-            _call = super().run_call_header.replace(
-                    f"-L node={self.nodes}",
-                    f"-L gpu={self.gpu}"
-                    )
-            return _call
-        else:
-            return super().run_call_header
-
-

--- a/seisflows/workflow/forward.py
+++ b/seisflows/workflow/forward.py
@@ -625,9 +625,11 @@ class Forward:
                 f"in `save_residuals`: {save_residuals}"
             )
             save_residuals = save_residuals.format(src=self.solver.source_name)
+            unix.mkdir(os.path.dirname(save_residuals)) 
 
         if self.export_residuals:
             export_residuals = os.path.join(self.path.output, "residuals")
+            unix.mkdir(export_residuals)
         else:
             export_residuals = False
 

--- a/seisflows/workflow/test_flow.py
+++ b/seisflows/workflow/test_flow.py
@@ -103,7 +103,7 @@ class TestFlow:
 
         # Force some internal module variables to keep testing lightweight
         logger.info("overwriting internal System parameters from given values")
-        # self.system.ntask = 3
+        self.system.ntask = 3
         self.system.nproc = 1
         self.system.tasktime = .25  # 15 seconds
         self.system.walltime = 2.5  # 2.5 minutes

--- a/seisflows/workflow/test_flow.py
+++ b/seisflows/workflow/test_flow.py
@@ -103,7 +103,7 @@ class TestFlow:
 
         # Force some internal module variables to keep testing lightweight
         logger.info("overwriting internal System parameters from given values")
-        self.system.ntask = 3
+        # self.system.ntask = 3
         self.system.nproc = 1
         self.system.tasktime = .25  # 15 seconds
         self.system.walltime = 2.5  # 2.5 minutes


### PR DESCRIPTION
General improvements to the U. Tokyo Fujitsu cluster Wisteria and multi-GPU workflows.

## Changelog:
- Overhauled `Fujitsu` System class to now allow parameter `ntask_max`. This is not an inherent option in Fujitsu-brand clusters so I needed to code it up directly in SeisFlows. General architecture is that SeisFlows submits `ntask_max` jobs to the System and monitors them, whenever a job completes, a new job is submitted to take its place, until `ntask` jobs have completed.
- Replace some default module loading in Wisteria custom run scripts to not use CUDA-aware MPI as this is not used in SPECFEM3D_Cartesian
- Shifted `residuals` directory creation into the responsibility of Workflow module, rather than preprocessing module, to keep dir. creation high-level
- Bugfix: Default preprocessing was not correctly attributing event origin time to synthetics which causes waveform timing mismatch when using real data (this was okay for synthetics because they both then had default timing)
- Bugfix: SPECFEM solver `nproc` check because there is a case where mpiexec gets defined to a default value for the system (if assigned NoneType), leading to serial runs when the User is expecting MPI processes. This is a redundant check to the System check
- Preprocessing modules (both Default and Pyaflowa) improved error logging
- Renamed log files for individual solver directories for `xgenerate_databases` as these were the same as the mesher (mesher -> database)
