### PR TITLE
Improve Model I/O speeds + QoL upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v3.4.1 (#230)
+- Replaces Optimize.gradient `save_vector` and `load_vector` functions internal I/O for Model class with read/write in native SPECFEM format, rather than in the middle-man .npz format which was taking excessive time
+- Models in the Optimization module are now saved in directories rather than as single files
+- Replaces all occurrences of .npz with references to the Model paths
+- Cleans up some of the Optimize.Gradient and Model class definitions and internal logic
+- Bugfix Model class was defining `os.getcwd()` once and for all in the path definition so changing paths and calling Model again was not updating this. Removed auto `path` setting since Model class depends on User explicitly setting path to activate the `setup` command. 
+- Adds a few additional log messages during the initialize line search function so that there isn't such a long gap without logging
+- #233 Model class now throws AssertionError if model `path` is empty (which might happen if a previous step failed quietly)
+- #234 remove log warning when get_task_id returns 0 since this is a feature not a bug
+- #236  adds smoothing option for `xsmooth_sem_pde` in SPECFEM3D, consolidates some of the smoothing code blocks
+
 ## v3.4.0 (#228)
 - Solver now allows input of list of parameters rather than using pre-defined labels to select. 
 - Moved all parameters setup and check tasks into the main Specfem solver module, rather than having it be distributed around the child classes

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
     - pyyaml
     - pypdf
     - pip:
-      #- pyatoa>=0.4.0
       - git+https://github.com/adjtomo/pyatoa.git@devel
       - pysep-adjtomo
       - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.4.0"
+version = "3.5.0"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -570,10 +570,8 @@ class Gradient:
         x, f, idx = self._line_search.get_search_history()
 
         # Figure out what step length and step count that corresponds to
-        _fidx = f.index(f.min())  # index of the minimum step length
         self.save_vector("f_new", f.min())
         logger.info(f"misfit of accepted trial model is f={f.min():.3E}")
-        logger.info(f"step count={idx[_fidx]}; step length={x[_fidx]:.3E}")
 
         logger.info("resetting line search step count to 0")
         self._line_search.step_count = 0

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -397,11 +397,11 @@ class Gradient:
                     f"{self.step_count}")
 
         # Log out the current line search stats for reference
-        x, f = self._line_search.get_search_history()
-        i_str = ", ".join([f"{_:>9}" for _ in range(len(x))])
-        x_str = ", ".join([f"{_:.3E}" for _ in x])
-        f_str = ", ".join([f"{_:.3E}" for _ in f])
-        logger.info(f"step count  = {i_str}")
+        x, f, idx = self._line_search.get_search_history()
+        idx_str = ", ".join([f"{_:>9}" for _ in idx])   # step count
+        x_str = ", ".join([f"{_:.3E}" for _ in x])  # step length
+        f_str = ", ".join([f"{_:.3E}" for _ in f])  # misfit value
+        logger.info(f"step count  = {idx_str}")
         logger.info(f"step length = {x_str}")
         logger.info(f"misfit val  = {f_str}")
 
@@ -565,9 +565,13 @@ class Gradient:
                 dst=os.path.join(self.path.scratch, "m_new"))
 
         # Choose minimum misfit value as final misfit/model. index 0 is initial
-        x, f = self._line_search.get_search_history()
+        x, f, idx = self._line_search.get_search_history()
+
+        # Figure out what step length and step count that corresponds to
+        _fidx = f.index(f.min())  # index of the minimum step length
         self.save_vector("f_new", f.min())
         logger.info(f"misfit of accepted trial model is f={f.min():.3E}")
+        logger.info(f"step count={idx[_fidx]}; step length={x[_fidx]:.3E}")
 
         logger.info("resetting line search step count to 0")
         self._line_search.step_count = 0
@@ -643,7 +647,7 @@ class Gradient:
         # step lengths (x) and function values/misfit (f)
         g = self.load_vector("g_new")
         p = self.load_vector("p_new")
-        x, f  = self._line_search.get_search_history()
+        x, f, _  = self._line_search.get_search_history()
         step_count = self._line_search.step_count
 
         # Construct statistics
@@ -684,7 +688,7 @@ class Gradient:
         # are set to 0 by default
         if not os.path.exists(fid):
             with open(fid, "w") as f_:
-                x, f  = self._line_search.get_search_history()
+                x, f, _  = self._line_search.get_search_history()
                 header = ",".join(keys) + "\n"
                 f_.write(header)
                 # Write values for first iteration

--- a/seisflows/optimize/gradient.py
+++ b/seisflows/optimize/gradient.py
@@ -371,6 +371,8 @@ class Gradient:
         f = self.load_vector("f_new")  # current misfit value from preprocess
         g = self.load_vector("g_new")  # current gradient from scaled kernels
         p = self.load_vector("p_new")  # current search direction
+        
+        logger.info("calculating gradient dot products GTG and GTP")
         gtg = dot(g.vector, g.vector)
         gtp = dot(g.vector, p.vector)
 

--- a/seisflows/plugins/line_search/backtrack.py
+++ b/seisflows/plugins/line_search/backtrack.py
@@ -58,7 +58,7 @@ class Backtrack(Bracket):
             status==how to treat the next step count evaluation)
         """
         # Determine the current line search history
-        x, f = self.get_search_history()
+        x, f, _ = self.get_search_history()
         first_iteration = bool(self.update_count == 1)
         first_step = bool(self.step_count == 1)
         

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -238,6 +238,7 @@ class Bracket:
         func_vals = np.array(self.func_vals[idx:])  # f
 
         # Sort by the step lengths taken
+        import pdb;pdb.set_trace()
         step_cnts = np.array(self.iteridx)[abs(step_lens).argsort()]
         func_vals = func_vals[abs(step_lens).argsort()]
         step_lens = step_lens[abs(step_lens).argsort()]

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -238,8 +238,7 @@ class Bracket:
         func_vals = np.array(self.func_vals[idx:])  # f
 
         # Sort by the step lengths taken
-        import pdb;pdb.set_trace()
-        step_cnts = np.array(self.iteridx)[abs(step_lens).argsort()]
+        step_cnts = np.arange(0, len(func_vals), 1)[abs(step_lens).argsort()]
         func_vals = func_vals[abs(step_lens).argsort()]
         step_lens = step_lens[abs(step_lens).argsort()]
 

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -130,7 +130,7 @@ class Bracket:
         :param step_len: length of step for the trial model (alpha)
         """
         # Quick check to make sure this is expected
-        x, f = self.get_search_history()
+        x, *_ = self.get_search_history()
         assert len(x) == self.step_count, \
             "update was not expected, step count does not match array length"
         
@@ -220,9 +220,10 @@ class Bracket:
             f = np.array(self.func_vals[k - i - 1:k])
             j = count_zeros(self.step_lens) - 1  # update count
 
-        :rtype: (np.array, np.array)
+        :rtype: (np.array, np.array, np.array)
         :return: (step lengths of current line search, 
-                  misfits of current line search)
+                  misfits of current line search,
+                  step count associated with given step length and misfit)
         """
         if not self.iteridx:
             logger.warning("line search has not yet been initialized")
@@ -237,10 +238,11 @@ class Bracket:
         func_vals = np.array(self.func_vals[idx:])  # f
 
         # Sort by the step lengths taken
+        step_cnts = self.iteridx[abs(step_lens).argsort()]
         func_vals = func_vals[abs(step_lens).argsort()]
         step_lens = step_lens[abs(step_lens).argsort()]
 
-        return step_lens, func_vals
+        return step_lens, func_vals, step_cnts
 
     def calculate_step_length(self):
         """
@@ -259,7 +261,7 @@ class Bracket:
             status==how to treat the next step count evaluation)
         """
         # Determine the line search history
-        x, f = self.get_search_history()  
+        x, f, _ = self.get_search_history()  
         # Some boolean checks to see where we're at in the inversion
         first_iteration = bool(self.update_count == 1)
         first_step = bool(self.step_count == 1)

--- a/seisflows/plugins/line_search/bracket.py
+++ b/seisflows/plugins/line_search/bracket.py
@@ -238,7 +238,7 @@ class Bracket:
         func_vals = np.array(self.func_vals[idx:])  # f
 
         # Sort by the step lengths taken
-        step_cnts = self.iteridx[abs(step_lens).argsort()]
+        step_cnts = np.array(self.iteridx)[abs(step_lens).argsort()]
         func_vals = func_vals[abs(step_lens).argsort()]
         step_lens = step_lens[abs(step_lens).argsort()]
 

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -980,7 +980,7 @@ class Specfem:
 
         # Determine which smoothing function we are using
         if self.smooth_type.lower() == "gaussian":  # 2D/3D/3D_GLOBE
-            cmd = "bin/xmooth_sem"
+            cmd = "bin/xsmooth_sem"
         elif self.smooth_type.lower() == "laplacian":  # 3D_GLOBE ONLY
             cmd = "bin/xsmooth_laplacian_sem"
             # laplacian smoothing expects span values in km, not m
@@ -1032,8 +1032,9 @@ class Specfem:
         """
         # Executable may come with additional sub arguments, we only need to
         # check that the actually executable exists
-        if not unix.which(executable.split(" ")[0]):
-            logger.critical(msg.cli(f"executable '{executable}' does not exist",
+        exc_check = executable.split(" ")[0]
+        if not unix.which(exc_check):
+            logger.critical(msg.cli(f"executable '{exc_check}' does not exist",
                             header="external solver error", border="="))
             sys.exit(-1)
 

--- a/seisflows/solver/specfem.py
+++ b/seisflows/solver/specfem.py
@@ -83,12 +83,12 @@ class Specfem:
     :param smooth_type: choose how smoothing is performed for gradients.
         these are tied to the internal smoothing functions available, and only
         certain code flavors have certain smoothing functions available:
-        - 'gaussian' [2D (default) /3D/3D_GLOBE]: convolve with a 3D gaussian, 
-            slow and computationally intensive. Default for SPECFEM2D and 3D
-        - 'laplacian' [3D_GLOBE]: average points around vertex to 
-            smooth.  faster and preferred method for GLOBE code
-        - 'pde' [3D]: diffusion-based PDE smoothing. for Cartesian code only, 
-            much faster than gaussian smoothing. See SPECFEM3D PR#1725
+        - 'gaussian' [2D/3D/3D_GLOBE]: Default, convolve with a 3D gaussian, 
+            slow and computationally intensive. Only option for 2D.
+        - 'laplacian' [3D_GLOBE]: RECOMMENDED FOR 3D_GLOBE. Average points 
+            around vertex to smooth. Much faster than Gaussian.
+        - 'pde' [3D]: RECOMMENDED for 3D. Diffusion-based PDE smoothing. 
+            Much faster than Gaussian. See SPECFEM3D PR#1725
     :type components: str
     :param components: components to search for synthetic data with. None by
         default which uses a wildcard when searching for synthetics. If

--- a/seisflows/solver/specfem2d.py
+++ b/seisflows/solver/specfem2d.py
@@ -42,6 +42,7 @@ class Specfem2D(Specfem):
         self.multiples = multiples
         self._f0 = None
         self._available_materials = ["ACOUSTIC", "ELASTIC", "2D_ANISOTROPIC"]
+        self._required_binaries.append("xsmooth_sem")
 
     def setup(self):
         """

--- a/seisflows/solver/specfem3d.py
+++ b/seisflows/solver/specfem3d.py
@@ -71,11 +71,15 @@ class Specfem3D(Specfem):
         self._required_binaries = ["xspecfem3D", "xmeshfem3D",
                                    "xgenerate_databases", "xcombine_sem",
                                    "xcombine_vol_data_vtk"]
-        
-        if self.smooth_type == "pde":
+
+        # Choose what type of smoothing to use
+        if self.smooth_type == "gaussian":
+            logger.warning("`smooth_type` 'gaussian' is very slow, recommend "
+                           "switching to type 'pde'")
+            self._required_binaries.append("xsmooth_sem")        
+        elif self.smooth_type == "pde":
+            
             self._required_binaries.append("xsmooth_sem_pde")
-        elif self.smooth_type == "gaussian":
-            self._required_binaries.append("xsmooth_sem")
         else:
             raise NotImplementedError("`smooth_type` must be 'pde' or "
                                       "'gaussian'")

--- a/seisflows/solver/specfem3d.py
+++ b/seisflows/solver/specfem3d.py
@@ -70,8 +70,16 @@ class Specfem3D(Specfem):
         self._acceptable_source_prefixes = ["CMTSOLUTION", "FORCESOLUTION"]
         self._required_binaries = ["xspecfem3D", "xmeshfem3D",
                                    "xgenerate_databases", "xcombine_sem",
-                                   "xsmooth_sem"]  #, "xcombine_vol_data_vtk"]
-
+                                   "xcombine_vol_data_vtk"]
+        
+        if self.smooth_type == "pde":
+            self._required_binaries.append("xsmooth_sem_pde")
+        elif self.smooth_type == "gaussian":
+            self._required_binaries.append("xsmooth_sem")
+        else:
+            raise NotImplementedError("`smooth_type` must be 'pde' or "
+                                      "'gaussian'")
+        
         # Overwriting constants that will be referenced during simulations 
         self._fwd_simulation_executables = [
             "bin/xmeshfem3D", "bin/xgenerate_databases", "bin/xspecfem3D"

--- a/seisflows/solver/specfem3d_globe.py
+++ b/seisflows/solver/specfem3d_globe.py
@@ -82,8 +82,8 @@ class Specfem3DGlobe(Specfem):
     __doc__ = Specfem.__doc__ + __doc__
 
     def __init__(self, source_prefix="CMTSOLUTION", export_vtk=True,
-                 prune_scratch=True,  regions="123", smooth_type="laplacian", 
-                 mask_source=False, scale_mask_region=False, **kwargs):
+                 prune_scratch=True,  regions="123", mask_source=False, 
+                 scale_mask_region=False, **kwargs):
         """
         Instantiate a Specfem3D_Globe solver interface
         
@@ -98,7 +98,6 @@ class Specfem3DGlobe(Specfem):
         """
         super().__init__(source_prefix=source_prefix, **kwargs)
 
-        self.smooth_type = smooth_type
         self.prune_scratch = prune_scratch
         self.mask_source = mask_source
         self.scale_mask_region = scale_mask_region
@@ -129,10 +128,12 @@ class Specfem3DGlobe(Specfem):
                                    "xcombine_vol_data_vtk"]
 
         # Choose what type of smoothing to use
-        if smooth_type == "laplacian":
-            self._required_binaries.append("xsmooth_laplacian_sem")
-        elif smooth_type == "gaussian":
+        if self.smooth_type == "gaussian":
+            logger.warning("`smooth_type` 'gaussian' is very slow, recommend "
+                           "switching to type 'laplacian'")
             self._required_binaries.append("xsmooth_sem")
+        elif self.smooth_type == "laplacian":
+            self._required_binaries.append("xsmooth_laplacian_sem")
         else:
             raise NotImplementedError("`smooth_type` must be 'laplacian' or "
                                       "'gaussian'")

--- a/seisflows/tools/config.py
+++ b/seisflows/tools/config.py
@@ -145,7 +145,6 @@ def get_task_id():
         if _taskid is not None:
             return int(_taskid)
     else:
-        logger.warning("Environment Task ID variable not found. Assigning 0")
         return 0
 
 

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -106,28 +106,20 @@ class Model:
 
         # Load an existing model if a valid path is given
         if self.path and os.path.exists(path):
-            # Read existing model from a previously saved .npz file
-            if os.path.splitext(path)[-1] == ".npz":
-                self.model, self.coordinates, self._ngll, self.fmt = \
-                    self.load(file=self.path)
-                _first_key = list(self.model.keys())[0]
-                self._nproc = len(self.model[_first_key])
-            # Read a SPECFEM model from its native output files
-            else:
-                # Dynamically guess things about the model based on files given
-                if not self.fmt:
-                    self.fmt = self._guess_file_format()
-                if not self.flavor:
-                    self.flavor = self._guess_specfem_flavor()
-    
-                # Gather internal representation of the model for manipulation
-                self._nproc, self.available_parameters = \
-                    self._get_nproc_parameters()
-                self.model = self.read(parameters=parameters)
+            # Dynamically guess things about the model based on files given
+            if not self.fmt:
+                self.fmt = self._guess_file_format()
+            if not self.flavor:
+                self.flavor = self._guess_specfem_flavor()
 
-                # Coordinates are only useful for SPECFEM2D models
-                if self.flavor == "2D":
-                    self.coordinates = self.read_coordinates_specfem2d()
+            # Gather internal representation of the model for manipulation
+            self._nproc, self.available_parameters = \
+                self._get_nproc_parameters()
+            self.model = self.read(parameters=parameters)
+
+            # Coordinates are only useful for SPECFEM2D models
+            if self.flavor == "2D":
+                self.coordinates = self.read_coordinates_specfem2d()
 
             # .sorted() enforces parameter order every time, otherwise things
             # can get screwy if keys returns different each time
@@ -773,6 +765,7 @@ class Model:
         Data are written as single precision floating point numbers
 
         .. note::
+        
             FORTRAN unformatted binaries are bounded by an INT*4 byte count.
             This function mimics that behavior by tacking on the boundary data
             as 'int32' at the top and bottom of the data array.

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -53,7 +53,7 @@ class Model:
         for region in ["1", "2", "3"]:
             acceptable_parameters.append(f"reg{region}_{parameter}")
     
-    def __init__(self, path=os.getcwd(), fmt="", parameters=None, regions="123", 
+    def __init__(self, path=None, fmt="", parameters=None, regions="123", 
                  flavor=None):
         """
         Model only needs path to model to determine model parameters. Format
@@ -85,7 +85,7 @@ class Model:
             to generate the model, acceptable values are ['2D', '3D', '3DGLOBE']
             If None, will try to guess based on file matching
         """
-        self.path = path
+        self.path = path or os.getcwd()
         self.fmt = fmt
         self.flavor = flavor
         self.model = None
@@ -324,11 +324,13 @@ class Model:
 
         return m
 
-    def write(self, path=os.getcwd(), fmt=None):
+    def write(self, path=None, fmt=None):
         """
         Save a SPECFEM model/gradient/kernel vector loaded into memory back to
         disk in the appropriate format expected by SPECFEM
         """
+        path = path or os.getcwd()
+        
         unix.mkdir(path)
         if fmt is None:
             assert (self.fmt is not None), f"must specifiy model format: `fmt`"

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -105,7 +105,7 @@ class Model:
                 f"User-defined `flavor' must be in {acceptable_flavors}"
 
         # Load an existing model if a valid path is given
-        if self.path and os.path.exists(path):
+        if self.path and os.path.exists(self.path):
             # Dynamically guess things about the model based on files given
             if not self.fmt:
                 self.fmt = self._guess_file_format()
@@ -281,10 +281,10 @@ class Model:
                 coordinates["x"].append(np.loadtxt(fid).T[:, 0])
                 coordinates["z"].append(np.loadtxt(fid).T[:, 0])
 
-        # If nothing is found even though we expected files to be there
+        # If no coordinates then move on, sometimes we don't save the 
+        # coordinates if we're just using the model for updates. But without
+        # coordinates the default plot functions will not work
         if not list(coordinates["x"]) or not list(coordinates["z"]):
-            logger.warning("no coordinates found for assumed SPECFEM2D model, "
-                           "will not be able to plot figures")
             return None
 
         # Internal check for parameter validity by checking length of coord
@@ -330,7 +330,7 @@ class Model:
         disk in the appropriate format expected by SPECFEM
         """
         path = path or os.getcwd()
-        
+
         unix.mkdir(path)
         if fmt is None:
             assert (self.fmt is not None), f"must specifiy model format: `fmt`"

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -498,37 +498,6 @@ class Model:
 
         np.savez(file=path, fmt=self.fmt, **model)
 
-    def _load2d3d(self, file):
-        """
-        Load in a previously saved .npz file containing model information
-        and re-create a Model instance matching the one that was `save`d
-
-        :type file: str
-        :param file: .npz file to load data from. Must have been created by
-            Model.save()
-        :rtype: tuple (Dict, list, str)
-        :return: (Model Dictionary, ngll points for each slice, file format)
-        """
-        model = Dict()
-        coords = Dict()
-        ngll = []
-        data = np.load(file=file)
-        for i, key in enumerate(data.files):
-            if key == "fmt":
-                continue
-            # Special case where we are using SPECFEM2D and carry around coords
-            elif "coord" in key:
-                coords[key[0]] = data[key]  # drop '_coord' suffix from `save`
-            else:
-                model[key] = data[key]
-                # Assign the number of GLL points per slice. Only needs to happen
-                # once because all model values should have same points/slice
-                if not ngll:
-                    for array in model[key]:
-                        ngll.append(len(array))
-
-        return model, coords, ngll, str(data["fmt"])
-
     def load(self, file):
         """
         Load in a previously saved .npz file containing model information

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -487,9 +487,14 @@ class Model:
 
     def save(self, path):
         """
+        THIS FUNCTION WILL BE REMOVED UPON THE NEXT MINOR UPDATE (v3.5.0)
+
         Save instance attributes (model, vector, metadata) to disk as an
         .npz array so that it can be loaded in at a later time for future use
         """
+        raise Exception("This functionality has been deprecated and will be "
+                        "removed from the Model class, see GitHub Issue #227")
+    
         model = self.split()
         if self.coordinates:
             # Incase we have model parameters called 'x' or 'z', rename for save
@@ -500,6 +505,8 @@ class Model:
 
     def load(self, file):
         """
+        THIS FUNCTION WILL BE REMOVED UPON THE NEXT MINOR UPDATE (v3.5.0)
+
         Load in a previously saved .npz file containing model information
         and re-create a Model instance matching the one that was `save`d
 
@@ -509,6 +516,9 @@ class Model:
         :rtype: tuple (Dict, list, str)
         :return: (Model Dictionary, ngll points for each slice, file format)
         """
+        raise Exception("This functionality has been deprecated and will be "
+                        "removed from the Model class, see GitHub Issue #227")
+    
         model = Dict()
         coords = Dict()
         ngll = []

--- a/seisflows/tools/model.py
+++ b/seisflows/tools/model.py
@@ -53,7 +53,6 @@ class Model:
         for region in ["1", "2", "3"]:
             acceptable_parameters.append(f"reg{region}_{parameter}")
     
-
     def __init__(self, path=os.getcwd(), fmt="", parameters=None, regions="123", 
                  flavor=None):
         """
@@ -333,7 +332,7 @@ class Model:
 
         return m
 
-    def write(self, path, fmt=None):
+    def write(self, path=os.getcwd(), fmt=None):
         """
         Save a SPECFEM model/gradient/kernel vector loaded into memory back to
         disk in the appropriate format expected by SPECFEM

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -534,7 +534,10 @@ class Inversion(Migration):
 
         # Determine the model we will use for first line search step count
         # m_try = m_new + alpha * p_new (i.e., m_i+1 = m_i + dm)
+        logger.info("calculating step length `alpha`")
         alpha, _ = self.optimize.calculate_step_length()
+        
+        logger.info("computing line search trial model `m_try`")
         m_try = self.optimize.compute_trial_model(alpha=alpha)
         
         # Save the current state of the optimization module to disk

--- a/seisflows/workflow/inversion.py
+++ b/seisflows/workflow/inversion.py
@@ -410,7 +410,7 @@ class Inversion(Migration):
                                             **kwargs)
 
             # Expose the initial model to the optimization library
-            model = Model(self.path.model_init,
+            model = Model(path=self.path.model_init,
                           parameters=self.solver._parameters,
                           regions=self.solver._regions  # req. for 3D_GLOBE only
                           )
@@ -536,7 +536,7 @@ class Inversion(Migration):
         # m_try = m_new + alpha * p_new (i.e., m_i+1 = m_i + dm)
         logger.info("calculating step length `alpha`")
         alpha, _ = self.optimize.calculate_step_length()
-        
+
         logger.info("computing line search trial model `m_try`")
         m_try = self.optimize.compute_trial_model(alpha=alpha)
         


### PR DESCRIPTION
See Issue #229 for description of the issue, relating to slow I/O for dictionaries of arrays being saved with NumPy savez. This PR replaces all that functionality with direct read/write ability in the native SPECFEM format (currently only GLL Fortran binary is supported, but kept general for future use with ADIOS format). Removes all references to .npz files used previously for model and gradient storage.

## Changelog
- Replaces Optimize.gradient `save_vector` and `load_vector` functions internal I/O for Model class with read/write in native SPECFEM format, rather than in the middle-man .npz format which was taking excessive time
- Models in the Optimization module are now saved in directories rather than as single files
- Replaces all occurrences of .npz with references to the Model paths
- Cleans up some of the Optimize.Gradient and Model class definitions and internal logic
- Bugfix Model class was defining `os.getcwd()` once and for all in the path definition so changing paths and calling Model again was not updating this. Removed auto `path` setting since Model class depends on User explicitly setting path to activate the `setup` command. 
- Adds a few additional log messages during the initialize line search function so that there isn't such a long gap without logging
- #233 Model class now throws AssertionError if model `path` is empty (which might happen if a previous step failed quietly)
- #234 remove log warning when get_task_id returns 0 since this is a feature not a bug
- #236  adds smoothing option for `xsmooth_sem_pde` in SPECFEM3D, consolidates some of the smoothing code blocks
