### PR TITLE
Fujitsu feature custom tasktime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v3.5.1 (#239)
+- Implements custom tasktimes in Fujitsu system
+- Modifies Fujitsu run_call structure to be more like Slurm system
+- Bugfix Fujitsu tasktime and walltime were not able to exceed 1 day
+- Bugfix: Slurm system class was using an undefined parameter
+
 ## v3.5.0 (#230)
 - Replaces Optimize.gradient `save_vector` and `load_vector` functions internal I/O for Model class with read/write in native SPECFEM format, rather than in the middle-man .npz format which was taking excessive time
 - Models in the Optimization module are now saved in directories rather than as single files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.5.0"
+version = "3.5.1"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/system/cluster.py
+++ b/seisflows/system/cluster.py
@@ -14,6 +14,7 @@ import os
 import sys
 import subprocess
 import time
+import numpy as np
 from concurrent.futures import ProcessPoolExecutor, wait
 from seisflows import logger, ROOT_DIR
 from seisflows.tools import msg

--- a/seisflows/system/fujitsu.py
+++ b/seisflows/system/fujitsu.py
@@ -69,15 +69,11 @@ class Fujitsu(Cluster):
         # Convert walltime and tasktime from minutes to str 'HH:MM:SS'
         # https://stackoverflow.com/questions/20291883/\
         #                           converting-minutes-to-hhmm-format-in-python
-        if not self.tasktime.is_integer() or not self.walltime.is_integer():
-            logger.warning("Fujitsu system cannot handle decimal minutes for "
-                           "`tasktime` or `walltime`, rounding up to the "
-                           "nearest whole minute"
-                           )
+        # Round because this only works for integers not floats
         self._tasktime = "{:02d}:{:02d}:00".format(
-            *divmod(np.ceil(self.tasktime), 60))
+            *divmod(round(self.tasktime), 60))
         self._walltime = "{:02d}:{:02d}:00".format(
-            *divmod(np.ceil(self.walltime), 60))
+            *divmod(round(self.walltime), 60))
     
         # Define PJM-dependent job states used for monitoring queue which
         # can be found in the User manual

--- a/seisflows/system/fujitsu.py
+++ b/seisflows/system/fujitsu.py
@@ -18,7 +18,6 @@ import numpy as np
 import time
 import subprocess
 
-from datetime import timedelta
 from seisflows import logger
 from seisflows.system.cluster import Cluster
 from seisflows.tools import msg
@@ -67,9 +66,18 @@ class Fujitsu(Cluster):
         self.gpu = None
         self._rscgrps = {}
 
-        # Convert walltime and tasktime to datetime str 'H:MM:SS'
-        self._tasktime = str(timedelta(minutes=self.tasktime))
-        self._walltime = str(timedelta(minutes=self.walltime))
+        # Convert walltime and tasktime from minutes to str 'HH:MM:SS'
+        # https://stackoverflow.com/questions/20291883/\
+        #                           converting-minutes-to-hhmm-format-in-python
+        if not self.tasktime.is_integer() or not self.walltime.is_integer():
+            logger.warning("Fujitsu system cannot handle decimal minutes for "
+                           "`tasktime` or `walltime`, rounding up to the "
+                           "nearest whole minute"
+                           )
+        self._tasktime = "{:02d}:{:02d}:00".format(
+            *divmod(np.ceil(self.tasktime), 60))
+        self._walltime = "{:02d}:{:02d}:00".format(
+            *divmod(np.ceil(self.walltime), 60))
     
         # Define PJM-dependent job states used for monitoring queue which
         # can be found in the User manual

--- a/seisflows/system/slurm.py
+++ b/seisflows/system/slurm.py
@@ -29,7 +29,6 @@ import numpy as np
 import time
 import subprocess
 
-from datetime import timedelta
 from seisflows import logger
 from seisflows.system.cluster import Cluster
 from seisflows.tools import msg
@@ -180,7 +179,7 @@ class Slurm(Cluster):
              f"--job-name={self.title}",
              f"--nodes={self.nodes}",
              f"--ntasks-per-node={self.node_size:d}",
-             f"--ntasks={ntasks:d}",
+             f"--ntasks={self.nproc:d}",
              f"--time={tasktime}",
              f"--output={os.path.join(self.path.log_files, '%A_%a')}",
              f"--array={array}",


### PR DESCRIPTION
The `Fujitsu` and child `Wisteria` classes did not have access to custom tasktimes like Slurm-derived system classes so we were unable to increase tasktimes for long tasks like smoothing. This PR implements that and adds a few bugfixes.

## Changelog
- Implements custom tasktimes in Fujitsu system
- Modifies Fujitsu run_call structure to be more like Slurm system
- Bugfix Fujitsu tasktime and walltime were not able to exceed 1 day
- Bugfix: Slurm system class was using an undefined parameter