### PR TITLE
Improve plot2d example graphics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seisflows"
-version = "3.5.4"
+version = "3.5.5"
 description = "An automated workflow tool for full waveform inversion"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/seisflows/seisflows.py
+++ b/seisflows/seisflows.py
@@ -222,12 +222,26 @@ def sfparser():
     plot2d.add_argument("name", type=str, nargs="?",
                         help="Name of directory in the output/ directory")
     plot2d.add_argument("parameter", type=str, nargs="?",
-                        help="Name of parameter to plot from `name`. E.g., 'vs', "
-                             "'vp' etc.")
+                        help="Name of parameter to plot from `name`. " 
+                             "E.g., 'vs', 'vp' etc.")
     plot2d.add_argument("-c", "--cmap", type=str, nargs="?",
-                        help="colormap to be passed to PyPlot")
+                        help="optional colormap otherwise default based on " 
+                             "quantity plotted")
+    plot2d.add_argument("--vmin", type=float, nargs="?",
+                        help="optional minimum colorbar bound")
+    plot2d.add_argument("--vmax", type=float, nargs="?",
+                        help="optional maximum colorbar bound")
+    plot2d.add_argument("-l", "--levels", type=int, nargs="?", default=101,
+                        help="discretization for colormap, default 101")
+    plot2d.add_argument("-C", "--center_cmap", action="store_true", 
+                        default=None,
+                        help="Center colormap around 0 using absmax value for "
+                             "bounds, useful for kernels. If not provided, "
+                             "will be auto applied for kernels only")
     plot2d.add_argument("-s", "--savefig", type=str, nargs="?", default=None,
                         help="optional name and path to save figure")
+    plot2d.add_argument("-n", "--noshow", action="store_true", default=False,
+                        help="Figure is shown by default, use `noshow` to not")
     # =========================================================================
     plotst = subparser.add_parser(
         "plotst", formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1181,7 +1195,8 @@ class SeisFlows:
 
         st.plot(outfile=savefig, **kwargs)
 
-    def plot2d(self, name=None, parameter=None, cmap=None, savefig=None,
+    def plot2d(self, name=None, parameter=None, vmin=None, vmax=None, cmap=None, 
+               center_cmap=False, levels=101, savefig=None, noshow=False, 
                **kwargs):
         """
         Plot model, gradient or kernels in the PATH.OUTPUT
@@ -1196,6 +1211,10 @@ class SeisFlows:
         :type savefig: str
         :param savefig: optional name and path of filename to save figure
             to disk
+        :type noshow: bool
+        :param noshow: Figure is shown by default, use `noshow` to not show 
+            figure after generation. Useful for scripting when you only want
+            to save figures
         """
         from seisflows.tools.model import Model
 
@@ -1225,9 +1244,12 @@ class SeisFlows:
         # Now read in the actual updated values and update the model
         plot_model = Model(path=os.path.join(output_dir, name))
         plot_model.coordinates = base_model.coordinates
+
         # plot2d has internal check for acceptable parameter value
-        plot_model.plot2d(parameter=parameter, cmap=cmap, show=True,
-                          title=f"{name} // {parameter}", save=savefig)
+        plot_model.plot2d(parameter=parameter, cmap=cmap, levels=levels, 
+                          center_cmap=center_cmap, vmin=vmin, vmax=vmax,
+                          title=f"{name} // {parameter}", show=not noshow, 
+                          save=savefig)
 
     def reset(self, choice=None, **kwargs):
         """

--- a/seisflows/tools/graphics.py
+++ b/seisflows/tools/graphics.py
@@ -263,11 +263,11 @@ def plot_2d_contour(x, z, data, cmap="viridis", zero_midpoint=False):
     return f, p, cbar
 
 
-def plot_2d_image(x, z, data, cmap="viridis", zero_midpoint=False,
-                  resX=1000, resZ=1000):
+def plot_2d_image(x, z, data, cmap="viridis", res_x=1000, res_z=1000, 
+                  vmin=None, vmax=None):
     """
     Plots values of a SPECEFM2D model/gradient by interpolating onto a regular 
-    grid
+    grid. Used for the SeisFlows command `seisflows plot2d`
 
     :type x: np.array
     :param x: x values of GLL mesh
@@ -296,14 +296,6 @@ def plot_2d_image(x, z, data, cmap="viridis", zero_midpoint=False,
     rx = r/np.sqrt(1 + r**2)
     ry = 1/np.sqrt(1 + r**2)
 
-    # Assign zero as the midpoint for things like gradients
-    if zero_midpoint:
-        abs_max_val = max(abs(data))
-        vmin = -1 * abs_max_val
-        vmax = abs_max_val
-    else:
-        vmin, vmax = None, None
-
     f = plt.figure(figsize=(10 * rx, 10 * ry))
 
     # trick interpolation using the maximum values of z in case of concave 
@@ -314,14 +306,14 @@ def plot_2d_image(x, z, data, cmap="viridis", zero_midpoint=False,
     z = np.append(z, [max(z), max(z)])
     data = np.append(data, [np.nan, np.nan])
 
-    xi = np.linspace(min(x), max(x), resX)
-    zi = np.linspace(min(z), max(z), resZ)
+    xi = np.linspace(min(x), max(x), res_x)
+    zi = np.linspace(min(z), max(z), res_z)
     X, Z = np.meshgrid(xi, zi)
-    V = griddata((x, z), data, (X, Z), method='linear')
+    V = griddata((x, z), data, (X, Z), method="linear")
     im = plt.imshow(V, vmax=vmax, vmin=vmin,
                     extent=[x.min(), x.max(), z.min(), z.max()],
                     cmap=cmap,
-                    origin='lower')
+                    origin="lower")
 
     cbar = plt.colorbar(im, shrink=0.8, pad=0.025)
     plt.axis("image")

--- a/seisflows/tools/graphics.py
+++ b/seisflows/tools/graphics.py
@@ -263,8 +263,8 @@ def plot_2d_contour(x, z, data, cmap="viridis", zero_midpoint=False):
     return f, p, cbar
 
 
-def plot_2d_image(x, z, data, cmap="viridis", res_x=1000, res_z=1000, 
-                  vmin=None, vmax=None):
+def plot_2d_image(x, z, data, res_x=1000, res_z=1000, cmap="viridis",
+                  vmin=None, vmax=None, levels=101):
     """
     Plots values of a SPECEFM2D model/gradient by interpolating onto a regular 
     grid. Used for the SeisFlows command `seisflows plot2d`
@@ -310,10 +310,13 @@ def plot_2d_image(x, z, data, cmap="viridis", res_x=1000, res_z=1000,
     zi = np.linspace(min(z), max(z), res_z)
     X, Z = np.meshgrid(xi, zi)
     V = griddata((x, z), data, (X, Z), method="linear")
-    im = plt.imshow(V, vmax=vmax, vmin=vmin,
-                    extent=[x.min(), x.max(), z.min(), z.max()],
-                    cmap=cmap,
-                    origin="lower")
+
+    # Get a colormap with discretized color levels
+    cmap = plt.get_cmap(cmap, levels)
+    im = plt.imshow(V, vmax=vmax, vmin=vmin, 
+                    extent=[x.min(), x.max(), z.min(), z.max()], cmap=cmap,
+                    origin="lower"
+                    )
 
     cbar = plt.colorbar(im, shrink=0.8, pad=0.025)
     plt.axis("image")


### PR DESCRIPTION
Improves the SeisFlows command line tool `seisflows plot2d` which is used for quickly plotting models/gradients/kernels from 2D problems, mostly used for visualizing results during SeisFlows examples problems.

New options include:
- cmap: choose Matplotlib colormap
- levels: discretization level of the colormap
- center_cmap: force colormap to center around zero. This is done by default for kernels but might be useful for other plotting
- vmin: choose lower bound of the colorbar
- vmax: choose upper bound of the colorbar
- noshow: do not show the GUI figure, useful if scripting this function

Bugfix includes being able to change colormap, before the function was failing with custom colormap inputs

Example below
```bash
seisflows plot2d GRADIENT_01 vs_kernel --cmap jet --levels 31 --center_cmap --vmin .0004 --vmax .0004
```
<img width="707" height="707" alt="Figure_1" src="https://github.com/user-attachments/assets/ba3666ab-f726-4367-afcd-84f959f8fce2" />
